### PR TITLE
Use swagger annotated resource interface

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -914,7 +914,7 @@ Simple ping method for probing the REST api. Returns 'pong' upon success
 
 ===== Content Type
 
-* application/json
+* text/plain
 
 ===== Responses
 

--- a/index.adoc
+++ b/index.adoc
@@ -79,7 +79,7 @@ Any existing directory with the same name will be removed before adding the new 
 | testConnection 
 |   
 | - 
-| null 
+| false 
 |  
 
 |===         
@@ -218,7 +218,7 @@ endif::internal-generation[]
     
 `GET /license`
 
-Retrieves license information
+Get all licenses information
 
 ===== Description 
 
@@ -292,7 +292,7 @@ endif::internal-generation[]
     
 `PUT /license`
 
-Adds a new license
+Set a new license
 
 ===== Description 
 
@@ -314,7 +314,7 @@ Existing license details are overwritten. Upon successful request, returns a `Li
 
 | body 
 |  <<string>> 
-| - 
+| X 
 |  
 |  
 
@@ -329,7 +329,7 @@ Existing license details are overwritten. Upon successful request, returns a `Li
 |Name| Description| Required| Default| Pattern
 
 | clear 
-| Clears license details before updating. This parameter is currently ignored.  
+| Clears license details before updating (Jira only).  
 | - 
 | false 
 |  
@@ -818,7 +818,7 @@ Sets global permissions for anonymous access to public pages and user profiles
 
 | PermissionAnonymousAccessBean 
 |  <<PermissionAnonymousAccessBean>> 
-| - 
+| X 
 |  
 |  
 

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/DirectoryResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/DirectoryResourceImpl.java
@@ -4,19 +4,16 @@ import com.sun.jersey.spi.container.ResourceFilters;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.model.DirectoryBean;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
+import de.aservo.atlassian.confapi.rest.api.DirectoryResource;
 import de.aservo.atlassian.confapi.service.api.DirectoryService;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -33,26 +30,18 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 @Produces(MediaType.APPLICATION_JSON)
 @ResourceFilters(AdminOnlyResourceFilter.class)
 @Component
-public class DirectoryResource {
+public class DirectoryResourceImpl implements DirectoryResource {
 
-    private static final Logger log = LoggerFactory.getLogger(DirectoryResource.class);
+    private static final Logger log = LoggerFactory.getLogger(DirectoryResourceImpl.class);
 
     private final DirectoryService directoryService;
 
     @Inject
-    public DirectoryResource(DirectoryService directoryService) {
+    public DirectoryResourceImpl(DirectoryService directoryService) {
         this.directoryService = checkNotNull(directoryService);
     }
 
     @GET
-    @Operation(
-            tags = { ConfAPI.DIRECTORIES },
-            summary = "Get the list of user directories",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = DirectoryBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            }
-    )
     public Response getDirectories() {
         final ErrorCollection errorCollection = new ErrorCollection();
         try {
@@ -66,18 +55,8 @@ public class DirectoryResource {
     }
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { ConfAPI.DIRECTORIES },
-            summary = "Add a new directory",
-            description = "Any existing directory with the same name will be removed before adding the new one",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = DirectoryBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            }
-    )
     public Response addDirectory(
-            @QueryParam("testConnection") boolean testConnection,
+            @QueryParam("testConnection") @DefaultValue("false") final boolean testConnection,
             @NotNull final DirectoryBean directory) {
 
         final ErrorCollection errorCollection = new ErrorCollection();

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/LicenceResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/LicenceResourceImpl.java
@@ -8,17 +8,14 @@ import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confapi.model.LicenseBean;
 import de.aservo.atlassian.confapi.model.LicensesBean;
+import de.aservo.atlassian.confapi.rest.api.LicenseResource;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -39,9 +36,9 @@ import static com.atlassian.confluence.setup.ConfluenceBootstrapConstants.DEFAUL
 @Produces(MediaType.APPLICATION_JSON)
 @ResourceFilters(AdminOnlyResourceFilter.class)
 @Component
-public class LicenceResource {
+public class LicenceResourceImpl implements LicenseResource {
 
-    private static final Logger log = LoggerFactory.getLogger(LicenceResource.class);
+    private static final Logger log = LoggerFactory.getLogger(LicenceResourceImpl.class);
 
     private final LicenseHandler licenseHandler;
 
@@ -51,7 +48,7 @@ public class LicenceResource {
      * @param licenseHandler the license handler
      */
     @Inject
-    public LicenceResource(@ComponentImport LicenseHandler licenseHandler) {
+    public LicenceResourceImpl(@ComponentImport LicenseHandler licenseHandler) {
         this.licenseHandler = licenseHandler;
     }
 
@@ -61,13 +58,7 @@ public class LicenceResource {
      * @return the license
      */
     @GET
-    @Operation(summary = "Retrieves license information",
-            tags = { ConfAPI.LICENSES },
-            description = "Upon successful request, returns a `LicensesBean` object containing license details",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            })
+    @Override
     public Response getLicenses() {
         final ErrorCollection errorCollection = new ErrorCollection();
         try {
@@ -90,16 +81,11 @@ public class LicenceResource {
      */
     @PUT
     @Consumes({MediaType.TEXT_PLAIN})
-    @Operation(summary = "Adds a new license",
-            tags = { ConfAPI.LICENSES },
-            description = "Existing license details are overwritten. Upon successful request, returns a `LicensesBean` object containing license details",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            })
+    @Override
     public Response setLicense(
-            @QueryParam("clear") @Parameter(description="Clears license details before updating. This parameter is currently ignored.") @DefaultValue("false") boolean clear,
-            String licenseKey) {
+            @QueryParam("clear") @DefaultValue("false") final boolean clear,
+            @NotNull final String licenseKey) {
+
         final ErrorCollection errorCollection = new ErrorCollection();
         try {
             licenseHandler.addProductLicense(DEFAULT_LICENSE_REGISTRY_KEY, licenseKey);
@@ -110,4 +96,5 @@ public class LicenceResource {
         }
         return Response.status(Response.Status.BAD_REQUEST).entity(errorCollection).build();
     }
+
 }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceImpl.java
@@ -14,12 +14,9 @@ import de.aservo.atlassian.confapi.exception.NoContentException;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confapi.model.MailServerPopBean;
 import de.aservo.atlassian.confapi.model.MailServerSmtpBean;
+import de.aservo.atlassian.confapi.rest.api.MailServerResource;
 import de.aservo.atlassian.confapi.util.MailProtocolUtil;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,16 +31,18 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 /**
  * Resource to set mail server configuration.
  */
 @Path(ConfAPI.MAIL_SERVER)
 @Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 @ResourceFilters(AdminOnlyResourceFilter.class)
 @Component
-public class MailServerResource {
+public class MailServerResourceImpl implements MailServerResource {
 
-    private static final Logger log = LoggerFactory.getLogger(MailServerResource.class);
+    private static final Logger log = LoggerFactory.getLogger(MailServerResourceImpl.class);
 
     @ComponentImport
     private final MailServerManager mailServerManager;
@@ -54,7 +53,7 @@ public class MailServerResource {
      * @param mailServerManager the injected {@link MailServerManager}
      */
     @Inject
-    public MailServerResource(
+    public MailServerResourceImpl(
             final MailServerManager mailServerManager) {
 
         this.mailServerManager = mailServerManager;
@@ -62,14 +61,7 @@ public class MailServerResource {
 
     @GET
     @Path(ConfAPI.MAIL_SERVER_SMTP)
-    @Operation(
-            tags = { ConfAPI.MAIL_SERVER },
-            summary = "Get the default SMTP mail server",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerSmtpBean.class))),
-                    @ApiResponse(responseCode = "204", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            }
-    )
+    @Override
     public Response getMailServerSmtp() {
         final ErrorCollection errorCollection = new ErrorCollection();
 
@@ -87,15 +79,7 @@ public class MailServerResource {
 
     @PUT
     @Path(ConfAPI.MAIL_SERVER_SMTP)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { ConfAPI.MAIL_SERVER },
-            summary = "Set the default SMTP mail server",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerSmtpBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            }
-    )
+    @Override
     public Response setMailServerSmtp(
             @NotNull final MailServerSmtpBean bean) {
 
@@ -161,14 +145,7 @@ public class MailServerResource {
 
     @GET
     @Path(ConfAPI.MAIL_SERVER_POP)
-    @Operation(
-            tags = { ConfAPI.MAIL_SERVER },
-            summary = "Get the default POP mail server",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerPopBean.class))),
-                    @ApiResponse(responseCode = "204", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            }
-    )
+    @Override
     public Response getMailServerPop() {
         final ErrorCollection errorCollection = new ErrorCollection();
 
@@ -186,15 +163,7 @@ public class MailServerResource {
 
     @PUT
     @Path(ConfAPI.MAIL_SERVER_POP)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { ConfAPI.MAIL_SERVER },
-            summary = "Set the default POP mail server",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerPopBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            }
-    )
+    @Override
     public Response setMailServerPop(
             @NotNull final MailServerPopBean bean) {
 

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceImpl.java
@@ -9,17 +9,13 @@ import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
 import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import de.aservo.atlassian.confluence.confapi.rest.api.PermissionsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -37,9 +33,9 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 @Produces(MediaType.APPLICATION_JSON)
 @ResourceFilters(AdminOnlyResourceFilter.class)
 @Component
-public class PermissionsResource {
+public class PermissionsResourceImpl implements PermissionsResource {
 
-    private static final Logger log = LoggerFactory.getLogger(PermissionsResource.class);
+    private static final Logger log = LoggerFactory.getLogger(PermissionsResourceImpl.class);
 
     private final AnonymousUserPermissionsService anonymousUserPermissionsService;
     private final SpacePermissionManager spacePermissionManager;
@@ -50,7 +46,7 @@ public class PermissionsResource {
      * @param anonymousUserPermissionsService the anonymous user permissions service
      */
     @Inject
-    public PermissionsResource(@ComponentImport AnonymousUserPermissionsService anonymousUserPermissionsService,
+    public PermissionsResourceImpl(@ComponentImport AnonymousUserPermissionsService anonymousUserPermissionsService,
                                @ComponentImport SpacePermissionManager spacePermissionManager) {
         this.anonymousUserPermissionsService = anonymousUserPermissionsService;
         this.spacePermissionManager = spacePermissionManager;
@@ -61,15 +57,7 @@ public class PermissionsResource {
      *
      * @return the global access permissions
      */
-    @GET
-    @Path(ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
-    @Operation(summary = "Retrieve current anonymous access configuration",
-            tags = { ConfAPI.PERMISSIONS },
-            description = "Gets the current global permissions for anonymous access to public pages and user profiles",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionAnonymousAccessBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            })
+    @Override
     public Response getPermissionAnonymousAccess() {
         final ErrorCollection errorCollection = new ErrorCollection();
         try {
@@ -91,16 +79,10 @@ public class PermissionsResource {
      * @param accessBean          bean describing the anonymous access
      * @return the global access permissions
      */
-    @PUT
-    @Path(ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
-    @Operation(summary = "Set anonymous access configuration",
-            tags = { ConfAPI.PERMISSIONS },
-            description = "Sets global permissions for anonymous access to public pages and user profiles",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionAnonymousAccessBean.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
-            })
-    public Response setPermissionAnonymousAccess(PermissionAnonymousAccessBean accessBean) {
+    @Override
+    public Response setPermissionAnonymousAccess(
+            @NotNull final PermissionAnonymousAccessBean accessBean) {
+
         final ErrorCollection errorCollection = new ErrorCollection();
         try {
             if (accessBean.getAllowForPages() != null) {
@@ -125,4 +107,5 @@ public class PermissionsResource {
         }
         return false;
     }
+
 }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PingResource.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PingResource.java
@@ -2,8 +2,7 @@ package de.aservo.atlassian.confluence.confapi.rest;
 
 import com.atlassian.plugins.rest.common.security.AnonymousAllowed;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import de.aservo.atlassian.confapi.rest.PingResourceInterface;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -13,19 +12,11 @@ import javax.ws.rs.core.Response;
 
 @Path(ConfAPI.PING)
 @AnonymousAllowed
-@Produces({MediaType.APPLICATION_JSON})
-public class PingResource {
-
-    public static final String PONG = "pong";
+@Produces(MediaType.TEXT_PLAIN)
+public class PingResource implements PingResourceInterface {
 
     @GET
-    @Operation(
-            tags = { ConfAPI.PING },
-            summary = "Simple ping method for probing the REST api. Returns 'pong' upon success",
-            responses = {
-                    @ApiResponse(responseCode = "200"),
-            }
-    )
+    @Override
     public Response getPing() {
         return Response.ok(PONG).build();
     }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PingResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PingResourceImpl.java
@@ -2,7 +2,7 @@ package de.aservo.atlassian.confluence.confapi.rest;
 
 import com.atlassian.plugins.rest.common.security.AnonymousAllowed;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
-import de.aservo.atlassian.confapi.rest.PingResourceInterface;
+import de.aservo.atlassian.confapi.rest.api.PingResource;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Response;
 @Path(ConfAPI.PING)
 @AnonymousAllowed
 @Produces(MediaType.TEXT_PLAIN)
-public class PingResource implements PingResourceInterface {
+public class PingResourceImpl implements PingResource {
 
     @GET
     @Override

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/SettingsResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/SettingsResourceImpl.java
@@ -6,11 +6,8 @@ import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.sun.jersey.spi.container.ResourceFilters;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.model.SettingsBean;
+import de.aservo.atlassian.confapi.rest.api.SettingsResource;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -28,29 +25,24 @@ import javax.ws.rs.core.Response;
  * Resource to set general configuration.
  */
 @Path(ConfAPI.SETTINGS)
-@Produces({MediaType.APPLICATION_JSON})
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 @ResourceFilters(AdminOnlyResourceFilter.class)
 @Component
-public class SettingsResource {
+public class SettingsResourceImpl implements SettingsResource {
 
     @ComponentImport
     private final SettingsManager settingsManager;
 
     @Inject
-    public SettingsResource(
+    public SettingsResourceImpl(
             final SettingsManager settingsManager) {
 
         this.settingsManager = settingsManager;
     }
 
     @GET
-    @Operation(
-            tags = { ConfAPI.SETTINGS },
-            summary = "Get the application settings",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBean.class))),
-            }
-    )
+    @Override
     public Response getSettings() {
         final Settings settings = settingsManager.getGlobalSettings();
 
@@ -62,14 +54,7 @@ public class SettingsResource {
     }
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { ConfAPI.SETTINGS },
-            summary = "Set the application settings",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBean.class))),
-            }
-    )
+    @Override
     public Response setSettings(
             @NotNull final SettingsBean bean) {
 

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/api/PermissionsResource.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/api/PermissionsResource.java
@@ -1,0 +1,46 @@
+package de.aservo.atlassian.confluence.confapi.rest.api;
+
+import de.aservo.atlassian.confapi.constants.ConfAPI;
+import de.aservo.atlassian.confapi.model.ErrorCollection;
+import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+public interface PermissionsResource {
+
+    @GET
+    @Path(ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
+    @Operation(
+            tags = { ConfAPI.PERMISSIONS },
+            summary = "Retrieve current anonymous access configuration",
+            description = "Gets the current global permissions for anonymous access to public pages and user profiles",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionAnonymousAccessBean.class))),
+                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+            }
+    )
+    Response getPermissionAnonymousAccess();
+
+    @PUT
+    @Path(ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
+    @Operation(
+            tags = { ConfAPI.PERMISSIONS },
+            summary = "Set anonymous access configuration",
+            description = "Sets global permissions for anonymous access to public pages and user profiles",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionAnonymousAccessBean.class))),
+                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+            }
+    )
+    Response setPermissionAnonymousAccess(
+            @NotNull PermissionAnonymousAccessBean accessBean);
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/DirectoryResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/DirectoryResourceTest.java
@@ -28,11 +28,11 @@ public class DirectoryResourceTest {
     @Mock
     private DirectoryService directoryService;
 
-    private DirectoryResource resource;
+    private DirectoryResourceImpl resource;
 
     @Before
     public void setup() {
-        resource = new DirectoryResource(directoryService);
+        resource = new DirectoryResourceImpl(directoryService);
     }
 
     @Test

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/LicenseResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/LicenseResourceTest.java
@@ -22,12 +22,12 @@ import static org.mockito.Mockito.*;
 public class LicenseResourceTest {
 
     private LicenseHandler licenseHandler;
-    private LicenceResource resource;
+    private LicenceResourceImpl resource;
 
     @Before
     public void setup() {
         licenseHandler = mock(LicenseHandler.class);
-        resource = new LicenceResource(licenseHandler);
+        resource = new LicenceResourceImpl(licenseHandler);
     }
 
     @Test

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceTest.java
@@ -32,11 +32,11 @@ public class MailServerResourceTest {
     @Mock
     private MailServerManager mailServerManager;
 
-    private MailServerResource mailServerResource;
+    private MailServerResourceImpl mailServerResource;
 
     @Before
     public void setup() {
-        mailServerResource = new MailServerResource(mailServerManager);
+        mailServerResource = new MailServerResourceImpl(mailServerManager);
     }
 
     @Test

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.doThrow;
 @RunWith(MockitoJUnitRunner.class)
 public class PermissionsResourceTest {
 
-    private PermissionsResource resource;
+    private PermissionsResourceImpl resource;
 
     @Mock
     private AnonymousUserPermissionsService anonymousUserPermissionsService;
@@ -33,7 +33,7 @@ public class PermissionsResourceTest {
 
     @Before
     public void setup() {
-        resource = new PermissionsResource(anonymousUserPermissionsService, spacePermissionManager);
+        resource = new PermissionsResourceImpl(anonymousUserPermissionsService, spacePermissionManager);
     }
 
     @Test

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PingResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PingResourceTest.java
@@ -10,17 +10,17 @@ import javax.ws.rs.core.Response;
 
 import static de.aservo.atlassian.confapi.junit.ResourceAssert.assertResourceMethodGetNoSubPath;
 import static de.aservo.atlassian.confapi.junit.ResourceAssert.assertResourcePath;
-import static de.aservo.atlassian.confluence.confapi.rest.PingResource.PONG;
+import static de.aservo.atlassian.confluence.confapi.rest.PingResourceImpl.PONG;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PingResourceTest {
 
-    private PingResource pingResource;
+    private PingResourceImpl pingResource;
 
     @Before
     public void setup() {
-        pingResource = new PingResource();
+        pingResource = new PingResourceImpl();
     }
 
     @Test

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/SettingsResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/SettingsResourceTest.java
@@ -26,11 +26,11 @@ public class SettingsResourceTest {
     @Mock
     private SettingsManager settingsManager;
 
-    private SettingsResource settingsResource;
+    private SettingsResourceImpl settingsResource;
 
     @Before
     public void setup() {
-        settingsResource = new SettingsResource(settingsManager);
+        settingsResource = new SettingsResourceImpl(settingsManager);
 
     }@Test
     public void testResourcePath() {
@@ -68,7 +68,7 @@ public class SettingsResourceTest {
         doReturn(defaultSettings).when(settingsManager).getGlobalSettings();
 
         final Settings updateSettings = new OtherTestSettings();
-        final SettingsResource resource = new SettingsResource(settingsManager);
+        final SettingsResourceImpl resource = new SettingsResourceImpl(settingsManager);
 
         final SettingsBean requestBean = new SettingsBean();
         requestBean.setBaseUrl(updateSettings.getBaseUrl());


### PR DESCRIPTION
It is possible to move the swagger annotation to resource interfaces. This has
the benefit that all features (annotations) of swagger (that make the code very
hard to read) can be used apart from the actual implementation but still in the
code. The other large benefit is that the same documentation can be shared
amongst all plugins (if needed).