### PR TITLE
Fix directories API

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -161,7 +161,7 @@ Get the list of user directories
 
 ===== Return Type
 
-<<DirectoryBean>>
+<<DirectoriesBean>>
 
 
 ===== Content Type
@@ -178,7 +178,7 @@ Get the list of user directories
 
 | 200
 | 
-|  <<DirectoryBean>>
+|  <<DirectoriesBean>>
 
 
 | 400
@@ -1111,6 +1111,25 @@ endif::internal-generation[]
 == Models
 
 
+[#DirectoriesBean]
+=== _DirectoriesBean_ 
+
+
+
+[.fields-DirectoriesBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| directories 
+|  
+| List  of <<DirectoryBean>> 
+| 
+|  
+
+|===
+
+
 [#DirectoryBean]
 === _DirectoryBean_ 
 
@@ -1471,6 +1490,12 @@ endif::internal-generation[]
 | Field Name| Required| Type| Description| Format
 
 | baseUrl 
+|  
+| String  
+| 
+|  
+
+| mode 
 |  
 | String  
 | 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <atlassian.gadgets.version>4.3.2.1</atlassian.gadgets.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.0.1-SNAPSHOT</confapi-commons.version>
+        <confapi-commons.version>0.0.2-SNAPSHOT</confapi-commons.version>
         <hibernate-validator.version>5.2.1.Final</hibernate-validator.version>
         <javax.el-api.version>2.2.4</javax.el-api.version>
         <junit.version>4.12</junit.version>

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/DirectoriesResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/DirectoriesResourceImpl.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.confluence.confapi.rest;
 
 import com.sun.jersey.spi.container.ResourceFilters;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
+import de.aservo.atlassian.confapi.model.DirectoriesBean;
 import de.aservo.atlassian.confapi.model.DirectoryBean;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confapi.rest.api.DirectoriesResource;
@@ -19,7 +20,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -43,8 +43,8 @@ public class DirectoriesResourceImpl implements DirectoriesResource {
     public Response getDirectories() {
         final ErrorCollection errorCollection = new ErrorCollection();
         try {
-            List<DirectoryBean> directories = directoryService.getDirectories();
-            return Response.ok(directories).build();
+            final DirectoriesBean directoriesBean = new DirectoriesBean(directoryService.getDirectories());
+            return Response.ok(directoriesBean).build();
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             errorCollection.addErrorMessage(e.getMessage());

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/DirectoriesResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/DirectoriesResourceTest.java
@@ -4,6 +4,7 @@ import com.atlassian.crowd.embedded.api.Directory;
 import com.atlassian.crowd.embedded.api.DirectoryType;
 import com.atlassian.crowd.exception.DirectoryCurrentlySynchronisingException;
 import com.atlassian.crowd.model.directory.DirectoryImpl;
+import de.aservo.atlassian.confapi.model.DirectoriesBean;
 import de.aservo.atlassian.confapi.model.DirectoryBean;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confapi.service.api.DirectoryService;
@@ -15,7 +16,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -44,9 +44,9 @@ public class DirectoriesResourceTest {
 
         final Response response = resource.getDirectories();
         assertEquals(200, response.getStatus());
-        @SuppressWarnings("unchecked") final List<DirectoryBean> DirectoryBeans = (List<DirectoryBean>) response.getEntity();
+        @SuppressWarnings("unchecked") final DirectoriesBean directoriesBean = (DirectoriesBean) response.getEntity();
 
-        assertEquals(initialDirectoryBean, DirectoryBeans.get(0));
+        assertEquals(initialDirectoryBean, directoriesBean.getDirectories().iterator().next());
     }
 
     @Test


### PR DESCRIPTION
The API (Getter) should return a DirectoriesBean. Currently it is returning a list of DirectoryBean but the Swagger documentation states it would be a (single) DirectoryBean.