### PR TITLE
Enable integration tests again, use resource_class 'large'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ executors:
   maven:
     docker:
       - image: circleci/openjdk:8-jdk
+    resource_class: large
     working_directory: /tmp/build
 
 jobs:
@@ -91,13 +92,13 @@ workflows:
           requires:
             - build
           context: global
-#     - integration-tests:
-#         requires:
-#           - build
+      - integration-tests:
+          requires:
+            - build
       - deploy:
           requires:
             - unit-tests
-#           - integration-tests
+            - integration-tests
           filters:
             branches:
               only: master


### PR DESCRIPTION
The integration tests didn't succeed anymore after the ConfAPI Commons library
has been integrated into the Confluence plugin. Probably this very small piece
of software caused that the default and free CircleCI machine equipped with 2
vCPUs and 4 GB RAM could not finish the integration tests anymore.

After switching to a paid plan, the pipeline can now choose from different
'resource classes' of which the class 'large' provides 4 vCPUs and 8 GB RAM. By
using this large resource class now, the integration tests can be executed
again.