### PR TITLE
Atlassian Dependency Removal from Commons Lib

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -81,7 +81,7 @@ Get the list of user directories
 |  <<DirectoriesBean>>
 
 
-| 400
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -181,7 +181,7 @@ Any existing directory with the same name will be removed before adding the new 
 |  <<DirectoryBean>>
 
 
-| 400
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -259,7 +259,7 @@ Upon successful request, returns a `LicensesBean` object containing license deta
 |  <<LicensesBean>>
 
 
-| 400
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -359,7 +359,7 @@ Existing license details are overwritten. Upon successful request, returns a `Li
 |  <<LicensesBean>>
 
 
-| 400
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -441,6 +441,11 @@ Get the default POP mail server
 | 
 |  <<ErrorCollection>>
 
+
+| 0
+| 
+|  <<ErrorCollection>>
+
 |===         
 
 ===== Samples
@@ -512,6 +517,11 @@ Get the default SMTP mail server
 
 
 | 204
+| 
+|  <<ErrorCollection>>
+
+
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -598,7 +608,7 @@ Set the default POP mail server
 |  <<MailServerPopBean>>
 
 
-| 400
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -685,7 +695,7 @@ Set the default SMTP mail server
 |  <<MailServerSmtpBean>>
 
 
-| 400
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -1001,6 +1011,11 @@ Get the application settings
 | 
 |  <<SettingsBean>>
 
+
+| 0
+| 
+|  <<ErrorCollection>>
+
 |===         
 
 ===== Samples
@@ -1082,6 +1097,11 @@ Set the application settings
 | 200
 | 
 |  <<SettingsBean>>
+
+
+| 0
+| 
+|  <<ErrorCollection>>
 
 |===         
 
@@ -1170,12 +1190,7 @@ Upon successful request, returns a `UserBean` object containing user details
 |  <<UserBean>>
 
 
-| 400
-| 
-|  <<ErrorCollection>>
-
-
-| 404
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -1275,12 +1290,7 @@ Upon successful request, returns the updated `UserBean` object.
 |  <<UserBean>>
 
 
-| 400
-| 
-|  <<ErrorCollection>>
-
-
-| 404
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -1380,12 +1390,7 @@ Upon successful request, returns the updated `UserBean` object (user name cannot
 |  <<UserBean>>
 
 
-| 400
-| 
-|  <<ErrorCollection>>
-
-
-| 404
+| 0
 | 
 |  <<ErrorCollection>>
 
@@ -1468,7 +1473,7 @@ endif::internal-generation[]
 | X 
 | String  
 | 
-|  _Enum:_ UNKNOWN, INTERNAL, CONNECTOR, CUSTOM, DELEGATING, CROWD, 
+|  
 
 | description 
 |  

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <atlassian.gadgets.version>4.3.2.1</atlassian.gadgets.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.0.4-SNAPSHOT</confapi-commons.version>
+        <confapi-commons.version>0.0.6-SNAPSHOT</confapi-commons.version>
         <hibernate-validator.version>5.2.1.Final</hibernate-validator.version>
         <javax.el-api.version>2.2.4</javax.el-api.version>
         <junit.version>4.12</junit.version>

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/DefaultAuthenticationScenario.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/DefaultAuthenticationScenario.java
@@ -1,0 +1,18 @@
+package de.aservo.atlassian.confluence.confapi.model;
+
+import com.atlassian.applinks.spi.auth.AuthenticationScenario;
+
+/**
+ * The type Default authentication scenario.
+ */
+public class DefaultAuthenticationScenario implements AuthenticationScenario {
+    @Override
+    public boolean isCommonUserBase() {
+        return true;
+    }
+
+    @Override
+    public boolean isTrusted() {
+        return true;
+    }
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/ApplicationLinkBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/ApplicationLinkBeanUtil.java
@@ -1,0 +1,89 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.application.bamboo.BambooApplicationType;
+import com.atlassian.applinks.api.application.bitbucket.BitbucketApplicationType;
+import com.atlassian.applinks.api.application.confluence.ConfluenceApplicationType;
+import com.atlassian.applinks.api.application.crowd.CrowdApplicationType;
+import com.atlassian.applinks.api.application.fecru.FishEyeCrucibleApplicationType;
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import de.aservo.atlassian.confapi.model.ApplicationLinkBean;
+import de.aservo.atlassian.confapi.model.type.ApplicationLinkTypes;
+import org.apache.commons.lang3.NotImplementedException;
+
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ApplicationLinkBeanUtil {
+
+    /**
+     * Instantiates a new Application link bean.
+     *
+     * @param linkDetails the link details
+     */
+    @NotNull
+    public static ApplicationLinkBean toApplicationLinkBean(
+            @NotNull final ApplicationLink linkDetails) {
+
+        final ApplicationLinkBean applicationLinkBean = new ApplicationLinkBean();
+        applicationLinkBean.setServerId(linkDetails.getId().toString());
+        applicationLinkBean.setAppType(linkDetails.getType().toString());
+        applicationLinkBean.setName(linkDetails.getName());
+        applicationLinkBean.setDisplayUrl(linkDetails.getDisplayUrl().toString());
+        applicationLinkBean.setRpcUrl(linkDetails.getRpcUrl().toString());
+        applicationLinkBean.setPrimary(linkDetails.isPrimary());
+        applicationLinkBean.setLinkType(getLinkTypeFromAppType(linkDetails.getType()));
+        return applicationLinkBean;
+    }
+
+    /**
+     * To application link details application link details.
+     *
+     * @return the application link details
+     * @throws URISyntaxException the uri syntax exception
+     */
+    @NotNull
+    public static ApplicationLinkDetails toApplicationLinkDetails(
+            @NotNull final ApplicationLinkBean applicationLinkBean) throws URISyntaxException {
+
+        return ApplicationLinkDetails.builder()
+                .name(applicationLinkBean.getName())
+                .displayUrl(new URI(applicationLinkBean.getDisplayUrl()))
+                .rpcUrl(new URI(applicationLinkBean.getRpcUrl()))
+                .isPrimary(applicationLinkBean.isPrimary())
+                .build();
+    }
+
+    /**
+     * Gets the linktype ApplicationLinkTypes enum value.
+     *
+     * @param type the ApplicationType
+     * @return the linktype
+     */
+    private static ApplicationLinkTypes getLinkTypeFromAppType(
+            @NotNull final ApplicationType type) {
+
+        if (type instanceof BambooApplicationType) {
+            return ApplicationLinkTypes.BAMBOO;
+        } else if (type instanceof JiraApplicationType) {
+            return ApplicationLinkTypes.JIRA;
+        } else if (type instanceof BitbucketApplicationType) {
+            return ApplicationLinkTypes.BITBUCKET;
+        } else if (type instanceof ConfluenceApplicationType) {
+            return ApplicationLinkTypes.CONFLUENCE;
+        } else if (type instanceof FishEyeCrucibleApplicationType) {
+            return ApplicationLinkTypes.FISHEYE;
+        } else if (type instanceof CrowdApplicationType) {
+            return ApplicationLinkTypes.CROWD;
+        } else {
+            throw new NotImplementedException("application type '" + type.getClass() + "' not implemented");
+        }
+    }
+
+    private ApplicationLinkBeanUtil() {
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
@@ -1,0 +1,81 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.crowd.embedded.api.Directory;
+import com.atlassian.crowd.embedded.api.DirectoryType;
+import com.atlassian.crowd.model.directory.ImmutableDirectory;
+import de.aservo.atlassian.confapi.model.DirectoryBean;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.atlassian.crowd.directory.RemoteCrowdDirectory.*;
+import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.*;
+import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.SyncGroupMembershipsAfterAuth.WHEN_AUTHENTICATION_CREATED_THE_USER;
+import static com.atlassian.crowd.model.directory.DirectoryImpl.ATTRIBUTE_KEY_USE_NESTED_GROUPS;
+
+public class DirectoryBeanUtil {
+
+    /**
+     * Build directory directory.
+     *
+     * @return the directory
+     */
+    @NotNull
+    public static Directory toDirectory(
+            @NotNull final DirectoryBean directoryBean) {
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(CROWD_SERVER_URL, directoryBean.getCrowdUrl());
+        attributes.put(APPLICATION_PASSWORD, directoryBean.getAppPassword());
+        attributes.put(APPLICATION_NAME, directoryBean.getClientName());
+        attributes.put(CROWD_HTTP_PROXY_HOST, directoryBean.getProxyHost());
+        attributes.put(CROWD_HTTP_PROXY_PORT, directoryBean.getProxyPort());
+        attributes.put(CROWD_HTTP_PROXY_USERNAME, directoryBean.getProxyUsername());
+        attributes.put(CROWD_HTTP_PROXY_PASSWORD, directoryBean.getProxyPassword());
+        attributes.put(CACHE_SYNCHRONISE_INTERVAL, "3600");
+        attributes.put(ATTRIBUTE_KEY_USE_NESTED_GROUPS, "false");
+        attributes.put(INCREMENTAL_SYNC_ENABLED, "true");
+        attributes.put(SYNC_GROUP_MEMBERSHIP_AFTER_SUCCESSFUL_USER_AUTH_ENABLED, WHEN_AUTHENTICATION_CREATED_THE_USER.getValue());
+
+        return ImmutableDirectory.builder(directoryBean.getName(), DirectoryBeanUtil.getDirectoryType(directoryBean), directoryBean.getImplClass())
+                .setActive(directoryBean.isActive())
+                .setAttributes(attributes)
+                .build();
+    }
+
+    /**
+     * Build user directory bean user directory bean.
+     *
+     * @param directory the directory
+     * @return the user directory bean
+     */
+    @NotNull
+    public static DirectoryBean toDirectoryBean(
+            @NotNull final Directory directory) {
+
+        final Map<String, String> attributes = directory.getAttributes();
+        final DirectoryBean directoryBean = new DirectoryBean();
+        directoryBean.setName(directory.getName());
+        directoryBean.setActive(directory.isActive());
+        directoryBean.setType(directory.getType().name());
+        directoryBean.setDescription(directory.getDescription());
+        directoryBean.setCrowdUrl(attributes.get(CROWD_SERVER_URL));
+        directoryBean.setClientName(attributes.get(APPLICATION_NAME));
+        directoryBean.setProxyHost(attributes.get(CROWD_HTTP_PROXY_HOST));
+        directoryBean.setProxyPort(attributes.get(CROWD_HTTP_PROXY_PORT));
+        directoryBean.setProxyUsername(attributes.get(CROWD_HTTP_PROXY_USERNAME));
+        directoryBean.setImplClass(directory.getImplementationClass());
+        return directoryBean;
+    }
+
+    public static DirectoryType getDirectoryType(
+            @NotNull final DirectoryBean directoryBean) {
+
+        return DirectoryType.valueOf(directoryBean.getType().toUpperCase());
+    }
+
+    private DirectoryBeanUtil() {
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/LicenseBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/LicenseBeanUtil.java
@@ -1,0 +1,33 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.sal.api.license.SingleProductLicenseDetailsView;
+import de.aservo.atlassian.confapi.model.LicenseBean;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+
+public class LicenseBeanUtil {
+
+    /**
+     * Instantiates a new License bean.
+     *
+     * @param productLicense the product license
+     */
+    @Nonnull
+    public static LicenseBean toLicenseBean(
+            @Nonnull final SingleProductLicenseDetailsView productLicense) {
+
+        final LicenseBean licenseBean = new LicenseBean();
+        licenseBean.setProducts(Collections.singletonList(productLicense.getProductDisplayName()));
+        licenseBean.setLicenseType(productLicense.getLicenseTypeName());
+        licenseBean.setOrganization(productLicense.getOrganisationName());
+        licenseBean.setDescription(productLicense.getDescription());
+        licenseBean.setExpiryDate(productLicense.getMaintenanceExpiryDate());
+        licenseBean.setNumUsers(productLicense.getNumberOfUsers());
+        return licenseBean;
+    }
+
+    private LicenseBeanUtil() {
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerPopBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerPopBeanUtil.java
@@ -1,0 +1,32 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.mail.server.PopMailServer;
+import de.aservo.atlassian.confapi.model.MailServerPopBean;
+
+import javax.annotation.Nullable;
+
+public class MailServerPopBeanUtil {
+
+    @Nullable
+    public static MailServerPopBean toMailServerPopBean(
+            @Nullable final PopMailServer popMailServer) {
+
+        if (popMailServer == null) {
+            return null;
+        }
+
+        final MailServerPopBean mailServerPopBean = new MailServerPopBean();
+        mailServerPopBean.setName(popMailServer.getName());
+        mailServerPopBean.setDescription(popMailServer.getDescription());
+        mailServerPopBean.setProtocol(popMailServer.getMailProtocol().getProtocol());
+        mailServerPopBean.setHost(popMailServer.getHostname());
+        mailServerPopBean.setPort(popMailServer.getPort());
+        mailServerPopBean.setTimeout(popMailServer.getTimeout());
+        mailServerPopBean.setUsername(popMailServer.getUsername());
+        return mailServerPopBean;
+    }
+
+    private MailServerPopBeanUtil() {
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerSmtpBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerSmtpBeanUtil.java
@@ -1,0 +1,35 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.mail.server.SMTPMailServer;
+import de.aservo.atlassian.confapi.model.MailServerSmtpBean;
+
+import javax.annotation.Nullable;
+
+public class MailServerSmtpBeanUtil {
+
+    @Nullable
+    public static MailServerSmtpBean toMailServerSmtpBean(
+            @Nullable final SMTPMailServer smtpMailServer) {
+
+        if (smtpMailServer == null) {
+            return null;
+        }
+
+        final MailServerSmtpBean mailServerSmtpBean = new MailServerSmtpBean();
+        mailServerSmtpBean.setName(smtpMailServer.getName());
+        mailServerSmtpBean.setDescription(smtpMailServer.getDescription());
+        mailServerSmtpBean.setFrom(smtpMailServer.getDefaultFrom());
+        mailServerSmtpBean.setPrefix(smtpMailServer.getPrefix());
+        mailServerSmtpBean.setProtocol(smtpMailServer.getMailProtocol().getProtocol());
+        mailServerSmtpBean.setHost(smtpMailServer.getHostname());
+        mailServerSmtpBean.setPort(smtpMailServer.getPort());
+        mailServerSmtpBean.setTls(smtpMailServer.isTlsRequired());
+        mailServerSmtpBean.setTimeout(smtpMailServer.getTimeout());
+        mailServerSmtpBean.setUsername(smtpMailServer.getUsername());
+        return mailServerSmtpBean;
+    }
+
+    private MailServerSmtpBeanUtil() {
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/LicencesResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/LicencesResourceImpl.java
@@ -6,10 +6,10 @@ import com.atlassian.sal.api.license.SingleProductLicenseDetailsView;
 import com.sun.jersey.spi.container.ResourceFilters;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
-import de.aservo.atlassian.confapi.model.LicenseBean;
 import de.aservo.atlassian.confapi.model.LicensesBean;
 import de.aservo.atlassian.confapi.rest.api.LicensesResource;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
+import de.aservo.atlassian.confluence.confapi.model.util.LicenseBeanUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -60,7 +60,7 @@ public class LicencesResourceImpl implements LicensesResource {
         try {
             SingleProductLicenseDetailsView conf = licenseHandler.getProductLicenseDetails(DEFAULT_LICENSE_REGISTRY_KEY);
             LicensesBean licensesBean = new LicensesBean();
-            licensesBean.setLicenses(Collections.singletonList(new LicenseBean(conf)));
+            licensesBean.setLicenses(Collections.singletonList(LicenseBeanUtil.toLicenseBean(conf)));
             return Response.ok(licensesBean).build();
         } catch (Exception e) {
             log.error(e.getMessage(), e);

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceImpl.java
@@ -10,13 +10,14 @@ import com.atlassian.mail.server.impl.SMTPMailServerImpl;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.sun.jersey.spi.container.ResourceFilters;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
-import de.aservo.atlassian.confapi.exception.NoContentException;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confapi.model.MailServerPopBean;
 import de.aservo.atlassian.confapi.model.MailServerSmtpBean;
 import de.aservo.atlassian.confapi.rest.api.MailServerResource;
-import de.aservo.atlassian.confapi.util.MailProtocolUtil;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
+import de.aservo.atlassian.confluence.confapi.model.util.MailServerPopBeanUtil;
+import de.aservo.atlassian.confluence.confapi.model.util.MailServerSmtpBeanUtil;
+import de.aservo.atlassian.confluence.confapi.util.MailProtocolUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,18 +60,9 @@ public class MailServerResourceImpl implements MailServerResource {
 
     @Override
     public Response getMailServerSmtp() {
-        final ErrorCollection errorCollection = new ErrorCollection();
-
-        try {
-            final SMTPMailServer smtpMailServer = mailServerManager.getDefaultSMTPMailServer();
-            final MailServerSmtpBean bean = MailServerSmtpBean.from(smtpMailServer);
-            return Response.ok(bean).build();
-        } catch (NoContentException e) {
-            log.error(e.getMessage(), e);
-            errorCollection.addErrorMessage(e.getMessage());
-        }
-
-        return Response.status(Response.Status.NO_CONTENT).entity(errorCollection).build();
+        final SMTPMailServer smtpMailServer = mailServerManager.getDefaultSMTPMailServer();
+        final MailServerSmtpBean bean = MailServerSmtpBeanUtil.toMailServerSmtpBean(smtpMailServer);
+        return Response.ok(bean).build();
     }
 
     @Override
@@ -139,18 +131,9 @@ public class MailServerResourceImpl implements MailServerResource {
 
     @Override
     public Response getMailServerPop() {
-        final ErrorCollection errorCollection = new ErrorCollection();
-
-        try {
-            final PopMailServer popMailServer = mailServerManager.getDefaultPopMailServer();
-            final MailServerPopBean bean = MailServerPopBean.from(popMailServer);
-            return Response.ok(bean).build();
-        } catch (NoContentException e) {
-            log.error(e.getMessage(), e);
-            errorCollection.addErrorMessage(e.getMessage());
-        }
-
-        return Response.status(Response.Status.NO_CONTENT).entity(errorCollection).build();
+        final PopMailServer popMailServer = mailServerManager.getDefaultPopMailServer();
+        final MailServerPopBean bean = MailServerPopBeanUtil.toMailServerPopBean(popMailServer);
+        return Response.ok(bean).build();
     }
 
     @Override

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceImpl.java
@@ -1,0 +1,134 @@
+package de.aservo.atlassian.confluence.confapi.service;
+
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.application.bamboo.BambooApplicationType;
+import com.atlassian.applinks.api.application.bitbucket.BitbucketApplicationType;
+import com.atlassian.applinks.api.application.confluence.ConfluenceApplicationType;
+import com.atlassian.applinks.api.application.crowd.CrowdApplicationType;
+import com.atlassian.applinks.api.application.fecru.FishEyeCrucibleApplicationType;
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+import com.atlassian.applinks.spi.auth.AuthenticationConfigurationException;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
+import com.atlassian.applinks.spi.manifest.ManifestNotFoundException;
+import com.atlassian.applinks.spi.util.TypeAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import de.aservo.atlassian.confapi.exception.BadRequestException;
+import de.aservo.atlassian.confapi.model.ApplicationLinkBean;
+import de.aservo.atlassian.confapi.model.type.ApplicationLinkTypes;
+import de.aservo.atlassian.confapi.service.api.ApplicationLinkService;
+import de.aservo.atlassian.confluence.confapi.model.DefaultAuthenticationScenario;
+import de.aservo.atlassian.confluence.confapi.model.util.ApplicationLinkBeanUtil;
+import org.apache.commons.lang3.NotImplementedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static de.aservo.atlassian.confapi.util.BeanValidationUtil.validate;
+
+/**
+ * The type Application link service.
+ */
+@Component
+@ExportAsService(ApplicationLinkService.class)
+public class ApplicationLinkServiceImpl implements ApplicationLinkService {
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationLinkServiceImpl.class);
+
+    private final MutatingApplicationLinkService mutatingApplicationLinkService;
+    private final TypeAccessor typeAccessor;
+
+    /**
+     * Instantiates a new Application link service.
+     *
+     * @param mutatingApplicationLinkService the application link service
+     * @param typeAccessor           the type accessor
+     */
+    @Inject
+    public ApplicationLinkServiceImpl(@ComponentImport MutatingApplicationLinkService mutatingApplicationLinkService,
+                                      @ComponentImport TypeAccessor typeAccessor) {
+        this.mutatingApplicationLinkService = mutatingApplicationLinkService;
+        this.typeAccessor = typeAccessor;
+    }
+
+    /**
+     * Gets application links.
+     *
+     * @return the application links
+     */
+    public List<ApplicationLinkBean> getApplicationLinks() {
+        Iterable<ApplicationLink> applicationLinksIterable = mutatingApplicationLinkService.getApplicationLinks();
+        return StreamSupport.stream(applicationLinksIterable.spliterator(), false)
+                .map(ApplicationLinkBeanUtil::toApplicationLinkBean)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Adds a new application link. NOTE: existing application links with the same type, e.g. "JIRA" will be
+     * removed before adding the new configuration.
+     *
+     * @param linkBean the link bean
+     * @return the added application ,link
+     */
+    public ApplicationLinkBean addApplicationLink(ApplicationLinkBean linkBean) {
+        //preparations
+        validate(linkBean);
+
+        ApplicationLinkDetails linkDetails;
+        try {
+            linkDetails = ApplicationLinkBeanUtil.toApplicationLinkDetails(linkBean);
+        } catch (URISyntaxException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+
+        ApplicationType applicationType = buildApplicationType(linkBean.getLinkType());
+
+        //check if there is already an application link of supplied type and if yes, remove it
+        Class<? extends ApplicationType> appType = applicationType != null ? applicationType.getClass() : null;
+        ApplicationLink primaryApplicationLink = mutatingApplicationLinkService.getPrimaryApplicationLink(appType);
+        if (primaryApplicationLink != null) {
+            log.info("An existing application link configuration '{}' was found and is removed now before adding the new configuration",
+                    primaryApplicationLink.getName());
+            mutatingApplicationLinkService.deleteApplicationLink(primaryApplicationLink);
+        }
+
+        //add new application link
+        ApplicationLink applicationLink;
+        try {
+            applicationLink = mutatingApplicationLinkService.createApplicationLink(applicationType, linkDetails);
+            mutatingApplicationLinkService.configureAuthenticationForApplicationLink(applicationLink,
+                    new DefaultAuthenticationScenario(), linkBean.getUsername(), linkBean.getPassword());
+        } catch (ManifestNotFoundException | AuthenticationConfigurationException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+
+        return ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
+    }
+
+    private ApplicationType buildApplicationType(ApplicationLinkTypes linkType) {
+        switch (linkType) {
+            case BAMBOO:
+                return typeAccessor.getApplicationType(BambooApplicationType.class);
+            case JIRA:
+                return typeAccessor.getApplicationType(JiraApplicationType.class);
+            case BITBUCKET:
+                return typeAccessor.getApplicationType(BitbucketApplicationType.class);
+            case CONFLUENCE:
+                return typeAccessor.getApplicationType(ConfluenceApplicationType.class);
+            case FISHEYE:
+                return typeAccessor.getApplicationType(FishEyeCrucibleApplicationType.class);
+            case CROWD:
+                return typeAccessor.getApplicationType(CrowdApplicationType.class);
+            default:
+                throw new NotImplementedException("application type '" + linkType + "' not implemented");
+        }
+    }
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceImpl.java
@@ -1,0 +1,68 @@
+package de.aservo.atlassian.confluence.confapi.service;
+
+import com.atlassian.crowd.embedded.api.CrowdDirectoryService;
+import com.atlassian.crowd.embedded.api.Directory;
+import com.atlassian.crowd.exception.DirectoryCurrentlySynchronisingException;
+import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import de.aservo.atlassian.confapi.exception.InternalServerErrorException;
+import de.aservo.atlassian.confapi.model.DirectoryBean;
+import de.aservo.atlassian.confapi.service.api.DirectoryService;
+import de.aservo.atlassian.confapi.util.BeanValidationUtil;
+import de.aservo.atlassian.confluence.confapi.model.util.DirectoryBeanUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Component
+@ExportAsService(DirectoryService.class)
+public class DirectoryServiceImpl implements DirectoryService {
+
+    private static final Logger log = LoggerFactory.getLogger(DirectoryServiceImpl.class);
+
+    private final CrowdDirectoryService crowdDirectoryService;
+
+    @Inject
+    public DirectoryServiceImpl(@ComponentImport CrowdDirectoryService crowdDirectoryService) {
+        this.crowdDirectoryService = checkNotNull(crowdDirectoryService);
+    }
+
+    public List<DirectoryBean> getDirectories() {
+        return crowdDirectoryService.findAllDirectories().stream().map(DirectoryBeanUtil::toDirectoryBean).collect(Collectors.toList());
+    }
+
+    public DirectoryBean setDirectory(DirectoryBean directoryBean, boolean testConnection) {
+
+        //preps and validation
+        BeanValidationUtil.validate(directoryBean);
+        Directory directory = DirectoryBeanUtil.toDirectory(directoryBean);
+        String directoryName = directoryBean.getName();
+        if (testConnection) {
+            log.debug("testing user directory connection for {}", directoryName);
+            crowdDirectoryService.testConnection(directory);
+        }
+
+        //check if directory exists already and if yes, remove it
+        Optional<Directory> presentDirectory = crowdDirectoryService.findAllDirectories().stream().filter(dir -> dir.getName().equals(directory.getName())).findFirst();
+        if (presentDirectory.isPresent()) {
+            Directory presentDir = presentDirectory.get();
+            log.info("removing existing user directory configuration '{}' before adding new configuration '{}'", presentDir.getName(), directory.getName());
+            try {
+                crowdDirectoryService.removeDirectory(presentDir.getId());
+            } catch (DirectoryCurrentlySynchronisingException e) {
+                throw new InternalServerErrorException(e.getMessage());
+            }
+        }
+
+        //add new directory
+        return DirectoryBeanUtil.toDirectoryBean(crowdDirectoryService.addDirectory(directory));
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/util/MailProtocolUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/util/MailProtocolUtil.java
@@ -1,0 +1,26 @@
+package de.aservo.atlassian.confluence.confapi.util;
+
+import com.atlassian.mail.MailProtocol;
+
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class MailProtocolUtil {
+
+    private MailProtocolUtil() {}
+
+    public static MailProtocol find(
+            final String protocol,
+            final MailProtocol defaultMailProtocol) {
+
+        if (isBlank(protocol)) {
+            return defaultMailProtocol;
+        }
+
+        return Arrays.stream(MailProtocol.values())
+                .filter(p -> p.getProtocol().equals(protocol))
+                .findAny().orElse(defaultMailProtocol);
+    }
+
+}

--- a/src/test/java/com/atlassian/confluence/settings/setup/DefaultApplicationLink.java
+++ b/src/test/java/com/atlassian/confluence/settings/setup/DefaultApplicationLink.java
@@ -1,0 +1,61 @@
+package com.atlassian.confluence.settings.setup;
+
+import com.atlassian.applinks.api.ApplicationId;
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationLinkRequestFactory;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.auth.AuthenticationProvider;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.net.URI;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DefaultApplicationLink implements ApplicationLink {
+
+    private ApplicationId id;
+    private ApplicationType type;
+    private String name;
+    private URI displayUrl;
+    private URI rpcUrl;
+    private boolean primary;
+    private boolean system;
+
+    @Override
+    public Object getProperty(String s) {
+        return null;
+    }
+
+    @Override
+    public Object putProperty(String s, Object o) {
+        return null;
+    }
+
+    @Override
+    public Object removeProperty(String s) {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createAuthenticatedRequestFactory() {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createAuthenticatedRequestFactory(Class<? extends AuthenticationProvider> aClass) {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createImpersonatingAuthenticatedRequestFactory() {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createNonImpersonatingAuthenticatedRequestFactory() {
+        return null;
+    }
+}

--- a/src/test/java/com/atlassian/confluence/settings/setup/DefaultApplicationType.java
+++ b/src/test/java/com/atlassian/confluence/settings/setup/DefaultApplicationType.java
@@ -1,0 +1,23 @@
+package com.atlassian.confluence.settings.setup;
+
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URI;
+
+public class DefaultApplicationType implements JiraApplicationType {
+
+    @Nonnull
+    @Override
+    public String getI18nKey() {
+        return "";
+    }
+
+    @Nullable
+    @Override
+    public URI getIconUrl() {
+        return null;
+    }
+
+}

--- a/src/test/java/com/atlassian/mail/server/DefaultTestMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestMailServer.java
@@ -1,0 +1,12 @@
+package com.atlassian.mail.server;
+
+public interface DefaultTestMailServer extends MailServer {
+
+    String NAME = "ASERVO Mail";
+    String DESCRIPTION = NAME + " Description";
+    String HOST = "mail.aservo.com";
+    long TIMEOUT = 0L;
+    String USERNAME = "username";
+    String PASSWORD = "p4$$w0rd";
+
+}

--- a/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServer.java
@@ -1,0 +1,11 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.MailConstants;
+import com.atlassian.mail.MailProtocol;
+
+public interface DefaultTestPopMailServer extends DefaultTestMailServer, PopMailServer {
+
+    MailProtocol PROTOCOL = MailConstants.DEFAULT_POP_PROTOCOL;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServerImpl.java
@@ -1,0 +1,21 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.PopMailServerImpl;
+
+public class DefaultTestPopMailServerImpl extends PopMailServerImpl implements DefaultTestPopMailServer {
+
+    public DefaultTestPopMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                PROTOCOL,
+                HOST,
+                PORT,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+}

--- a/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServer.java
@@ -1,0 +1,14 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.MailConstants;
+import com.atlassian.mail.MailProtocol;
+
+public interface DefaultTestSmtpMailServer extends DefaultTestMailServer, SMTPMailServer {
+
+    String FROM = "mail@aservo.com";
+    String PREFIX = "[ASERVO]";
+    boolean TLS_REQUIRED = false;
+    MailProtocol PROTOCOL = MailConstants.DEFAULT_SMTP_PROTOCOL;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServerImpl.java
@@ -1,0 +1,25 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.SMTPMailServerImpl;
+
+public class DefaultTestSmtpMailServerImpl extends SMTPMailServerImpl implements DefaultTestSmtpMailServer {
+
+    public DefaultTestSmtpMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                FROM,
+                PREFIX,
+                false,
+                PROTOCOL,
+                HOST,
+                PORT,
+                TLS_REQUIRED,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+}

--- a/src/test/java/com/atlassian/mail/server/OtherTestMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestMailServer.java
@@ -1,0 +1,12 @@
+package com.atlassian.mail.server;
+
+public interface OtherTestMailServer extends MailServer {
+
+    String NAME = "OTHER Mail";
+    String DESCRIPTION = NAME + " Description";
+    String HOST = "other.aservo.com";
+    long TIMEOUT = 10000L;
+    String USERNAME = "otheruser";
+    String PASSWORD = "otherpass";
+
+}

--- a/src/test/java/com/atlassian/mail/server/OtherTestPopMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestPopMailServer.java
@@ -1,0 +1,10 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.MailProtocol;
+
+public interface OtherTestPopMailServer extends DefaultTestMailServer, PopMailServer {
+
+    MailProtocol PROTOCOL = MailProtocol.IMAP;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/com/atlassian/mail/server/OtherTestPopMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestPopMailServerImpl.java
@@ -1,0 +1,23 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.PopMailServerImpl;
+
+public class OtherTestPopMailServerImpl extends PopMailServerImpl implements OtherTestPopMailServer {
+
+    public OtherTestPopMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                PROTOCOL,
+                HOST,
+                PORT,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+
+
+}

--- a/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServer.java
@@ -1,0 +1,13 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.MailProtocol;
+
+public interface OtherTestSmtpMailServer extends DefaultTestMailServer, SMTPMailServer {
+
+    String FROM = "from.other@aservo.com";
+    String PREFIX = "[OTHER]";
+    boolean TLS_REQUIRED = true;
+    MailProtocol PROTOCOL = MailProtocol.SECURE_SMTP;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServerImpl.java
@@ -1,0 +1,25 @@
+package com.atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.SMTPMailServerImpl;
+
+public class OtherTestSmtpMailServerImpl extends SMTPMailServerImpl implements OtherTestSmtpMailServer {
+
+    public OtherTestSmtpMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                FROM,
+                PREFIX,
+                false,
+                PROTOCOL,
+                HOST,
+                PORT,
+                TLS_REQUIRED,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/type/DefaultAuthenticationScenarioTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/type/DefaultAuthenticationScenarioTest.java
@@ -1,0 +1,20 @@
+package de.aservo.atlassian.confluence.confapi.model.type;
+
+import de.aservo.atlassian.confluence.confapi.model.DefaultAuthenticationScenario;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultAuthenticationScenarioTest {
+
+    @Test
+    public void testDefaultReturnValues() {
+        DefaultAuthenticationScenario scenario = new DefaultAuthenticationScenario();
+        assertTrue(scenario.isCommonUserBase());
+        assertTrue(scenario.isTrusted());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/ApplicationLinkBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/ApplicationLinkBeanUtilTest.java
@@ -1,0 +1,105 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.applinks.api.ApplicationId;
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.application.bamboo.BambooApplicationType;
+import com.atlassian.applinks.api.application.bitbucket.BitbucketApplicationType;
+import com.atlassian.applinks.api.application.confluence.ConfluenceApplicationType;
+import com.atlassian.applinks.api.application.crowd.CrowdApplicationType;
+import com.atlassian.applinks.api.application.fecru.FishEyeCrucibleApplicationType;
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+import com.atlassian.applinks.api.application.refapp.RefAppApplicationType;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import com.atlassian.confluence.settings.setup.DefaultApplicationLink;
+import com.atlassian.confluence.settings.setup.DefaultApplicationType;
+import de.aservo.atlassian.confapi.model.ApplicationLinkBean;
+import de.aservo.atlassian.confapi.model.type.ApplicationLinkTypes;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplicationLinkBeanUtilTest {
+
+    @Test
+    public void testToApplicationLinkBean() throws URISyntaxException {
+        final ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+        final URI displayUri = new URI("http://localhost");
+        final URI rpcUri = new URI("http://rpc.example.com");
+        final ApplicationLink applicationLink = new DefaultApplicationLink(
+                applicationId, new DefaultApplicationType(), "test", displayUri, rpcUri, false, false);
+        final ApplicationLinkBean bean =ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
+
+        assertNotNull(bean);
+        assertEquals(bean.getName(), applicationLink.getName());
+        assertEquals(bean.getDisplayUrl(), applicationLink.getDisplayUrl().toString());
+        assertEquals(bean.getRpcUrl(), applicationLink.getRpcUrl().toString());
+        assertEquals(bean.isPrimary(), applicationLink.isPrimary());
+    }
+
+    @Test
+    public void testToApplicationLinkDetails() throws Exception {
+        final ApplicationLinkBean bean = ApplicationLinkBean.EXAMPLE_1;
+        final ApplicationLinkDetails linkDetails = ApplicationLinkBeanUtil.toApplicationLinkDetails(bean);
+
+        assertNotNull(linkDetails);
+        assertEquals(bean.getName(), linkDetails.getName());
+        assertEquals(bean.getDisplayUrl(), linkDetails.getDisplayUrl().toString());
+        assertEquals(bean.getRpcUrl(), linkDetails.getRpcUrl().toString());
+        assertEquals(bean.isPrimary(), linkDetails.isPrimary());
+    }
+
+    @Test
+    public void testLinkTypeGenerator() throws URISyntaxException {
+        for (ApplicationLinkTypes linkType : ApplicationLinkTypes.values()) {
+            ApplicationType applicationType = null;
+            switch (linkType) {
+                case BAMBOO:
+                    applicationType = mock(BambooApplicationType.class);
+                    break;
+                case JIRA:
+                    applicationType = mock(JiraApplicationType.class);
+                    break;
+                case BITBUCKET:
+                    applicationType = mock(BitbucketApplicationType.class);
+                    break;
+                case CONFLUENCE:
+                    applicationType = mock(ConfluenceApplicationType.class);
+                    break;
+                case FISHEYE:
+                    applicationType = mock(FishEyeCrucibleApplicationType.class);
+                    break;
+                case CROWD:
+                    applicationType = mock(CrowdApplicationType.class);
+                    break;
+            }
+            ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+            URI uri = new URI("http://localhost");
+            ApplicationLink applicationLink = new DefaultApplicationLink(
+                    applicationId, applicationType, "test", uri, uri, false, false);
+            ApplicationLinkBean bean = ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
+            assertEquals(linkType, bean.getLinkType());
+        }
+    }
+
+    @Test(expected = NotImplementedException.class)
+    public void testNonImplementedLinkTypeGenerator() throws URISyntaxException {
+        ApplicationType applicationType = mock(RefAppApplicationType.class);
+        ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+        URI uri = new URI("http://localhost");
+        ApplicationLink applicationLink = new DefaultApplicationLink(
+                applicationId, applicationType, "test", uri, uri, false, false);
+        ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
@@ -1,0 +1,66 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.crowd.embedded.api.Directory;
+import com.atlassian.crowd.embedded.api.DirectoryType;
+import com.atlassian.crowd.model.directory.DirectoryImpl;
+import de.aservo.atlassian.confapi.model.DirectoryBean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static com.atlassian.crowd.directory.RemoteCrowdDirectory.*;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DirectoryBeanUtilTest {
+
+    @Test
+    public void testToDirectory() {
+        final DirectoryBean bean = DirectoryBean.EXAMPLE_1;
+        final Directory directory = DirectoryBeanUtil.toDirectory(bean);
+
+        assertNotNull(directory);
+        assertEquals(directory.getName(), bean.getName());
+        assertEquals(directory.getType().name(), bean.getType().toUpperCase());
+        assertEquals(directory.getImplementationClass(), bean.getImplClass());
+
+        final Map<String, String> attributes = directory.getAttributes();
+        assertEquals(attributes.get(CROWD_SERVER_URL), bean.getCrowdUrl());
+        assertEquals(attributes.get(APPLICATION_PASSWORD), bean.getAppPassword());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_HOST), bean.getProxyHost());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_PORT), bean.getProxyPort());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_USERNAME), bean.getProxyUsername());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_PASSWORD), bean.getProxyPassword());
+    }
+
+    @Test
+    public void testToDirectoryBean() {
+        final DirectoryImpl directory = new DirectoryImpl("test", DirectoryType.CROWD, "test.class");
+        directory.setAttribute(CROWD_SERVER_URL, "http://localhost");
+        directory.setAttribute(APPLICATION_PASSWORD, "test");
+        directory.setAttribute(APPLICATION_NAME, "confluence-client");
+        directory.setAttribute(CROWD_HTTP_PROXY_HOST, "http://localhost/proxy");
+        directory.setAttribute(CROWD_HTTP_PROXY_PORT, "8080");
+        directory.setAttribute(CROWD_HTTP_PROXY_USERNAME, "user");
+        directory.setAttribute(CROWD_HTTP_PROXY_PASSWORD, "pass");
+
+        final DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
+
+        assertNotNull(directoryBean);
+        assertEquals(directory.getName(), directoryBean.getName());
+        assertEquals(directory.getType().name(), directoryBean.getType());
+        assertEquals(directory.getImplementationClass(), directoryBean.getImplClass());
+
+        final Map<String, String> attributes = directory.getAttributes();
+        assertEquals(attributes.get(CROWD_SERVER_URL), directoryBean.getCrowdUrl());
+        assertEquals(attributes.get(APPLICATION_NAME), directoryBean.getClientName());
+        assertNull(directoryBean.getAppPassword());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_HOST), directoryBean.getProxyHost());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_PORT), directoryBean.getProxyPort());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_USERNAME), directoryBean.getProxyUsername());
+        assertNull(directoryBean.getProxyPassword());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/LicenseBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/LicenseBeanUtilTest.java
@@ -1,0 +1,30 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.sal.api.license.SingleProductLicenseDetailsView;
+import de.aservo.atlassian.confapi.model.LicenseBean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LicenseBeanUtilTest {
+
+    @Test
+    public void testToLicenseBean() {
+        final SingleProductLicenseDetailsView license = mock(SingleProductLicenseDetailsView.class);
+        final LicenseBean bean = LicenseBeanUtil.toLicenseBean(license);
+
+        assertNotNull(bean);
+        assertEquals(bean.getProducts().iterator().next(), license.getProductDisplayName());
+        assertEquals(bean.getOrganization(), license.getOrganisationName());
+        assertEquals(bean.getLicenseType(), license.getLicenseTypeName());
+        assertEquals(bean.getDescription(), license.getDescription());
+        assertEquals(bean.getExpiryDate(), license.getMaintenanceExpiryDate());
+        assertEquals(bean.getNumUsers(), license.getNumberOfUsers());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerPopBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerPopBeanUtilTest.java
@@ -1,0 +1,41 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.mail.server.DefaultTestPopMailServerImpl;
+import com.atlassian.mail.server.PopMailServer;
+import de.aservo.atlassian.confapi.model.MailServerPopBean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MailServerPopBeanUtilTest {
+
+    @Test
+    public void testToMailServerPopBean() {
+        final PopMailServer server = new DefaultTestPopMailServerImpl();
+        final MailServerPopBean bean = MailServerPopBeanUtil.toMailServerPopBean(server);
+
+        assertNotNull(bean);
+        assertEquals(server.getName(), bean.getName());
+        assertEquals(server.getDescription(), bean.getDescription());
+        assertEquals(server.getMailProtocol().getProtocol(), bean.getProtocol());
+        assertEquals(server.getHostname(), bean.getHost());
+        assertEquals(Integer.valueOf(server.getPort()), bean.getPort());
+        assertEquals(server.getTimeout(), bean.getTimeout());
+        assertEquals(server.getUsername(), bean.getUsername());
+        assertNull(bean.getPassword());
+    }
+
+    @Test
+    public void testToMailServerPopBeanHideEmptyDescription() {
+        final PopMailServer server = new DefaultTestPopMailServerImpl();
+        server.setDescription("");
+        final MailServerPopBean bean = MailServerPopBeanUtil.toMailServerPopBean(server);
+
+        assertNotNull(bean);
+        assertNull(bean.getDescription());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerSmtpBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerSmtpBeanUtilTest.java
@@ -1,0 +1,44 @@
+package de.aservo.atlassian.confluence.confapi.model.util;
+
+import com.atlassian.mail.server.DefaultTestSmtpMailServerImpl;
+import com.atlassian.mail.server.SMTPMailServer;
+import de.aservo.atlassian.confapi.model.MailServerSmtpBean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MailServerSmtpBeanUtilTest {
+
+    @Test
+    public void testToMailServerSmtpBean() {
+        final SMTPMailServer server = new DefaultTestSmtpMailServerImpl();
+        final MailServerSmtpBean bean = MailServerSmtpBeanUtil.toMailServerSmtpBean(server);
+
+        assertNotNull(bean);
+        assertEquals(server.getName(), bean.getName());
+        assertEquals(server.getDescription(), bean.getDescription());
+        assertEquals(server.getDefaultFrom(), bean.getFrom());
+        assertEquals(server.getPrefix(), bean.getPrefix());
+        assertEquals(server.getMailProtocol().getProtocol(), bean.getProtocol());
+        assertEquals(server.getHostname(), bean.getHost());
+        assertEquals(Integer.valueOf(server.getPort()), bean.getPort());
+        assertEquals(server.isTlsRequired(), bean.isTls());
+        assertEquals(server.getTimeout(), bean.getTimeout());
+        assertEquals(server.getUsername(), bean.getUsername());
+        assertNull(bean.getPassword());
+    }
+
+    @Test
+    public void testToMailServerSmtpBeanHideEmptyDescription() {
+        final SMTPMailServer server = new DefaultTestSmtpMailServerImpl();
+        server.setDescription("");
+        final MailServerSmtpBean bean = MailServerSmtpBeanUtil.toMailServerSmtpBean(server);
+
+        assertNotNull(bean);
+        assertNull(bean.getDescription());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/LicensesResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/LicensesResourceTest.java
@@ -4,8 +4,8 @@ import com.atlassian.sal.api.i18n.InvalidOperationException;
 import com.atlassian.sal.api.license.LicenseHandler;
 import com.atlassian.sal.api.license.SingleProductLicenseDetailsView;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
-import de.aservo.atlassian.confapi.model.LicenseBean;
 import de.aservo.atlassian.confapi.model.LicensesBean;
+import de.aservo.atlassian.confluence.confapi.model.util.LicenseBeanUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,7 +40,7 @@ public class LicensesResourceTest {
         assertEquals(200, response.getStatus());
         final LicensesBean licensesBean = (LicensesBean) response.getEntity();
 
-        assertEquals(licensesBean.getLicenses().iterator().next(), new LicenseBean(view));
+        assertEquals(licensesBean.getLicenses().iterator().next(), LicenseBeanUtil.toLicenseBean(view));
     }
 
     @Test

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/MailServerResourceTest.java
@@ -12,6 +12,8 @@ import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confapi.model.MailServerPopBean;
 import de.aservo.atlassian.confapi.model.MailServerSmtpBean;
+import de.aservo.atlassian.confluence.confapi.model.util.MailServerPopBeanUtil;
+import de.aservo.atlassian.confluence.confapi.model.util.MailServerSmtpBeanUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,10 +74,8 @@ public class MailServerResourceTest {
         doReturn(null).when(mailServerManager).getDefaultSMTPMailServer();
 
         final Response response = mailServerResource.getMailServerSmtp();
-        final ErrorCollection bean = (ErrorCollection) response.getEntity();
 
-        assertEquals(response.getStatus(), Status.NO_CONTENT.getStatusCode());
-        assertTrue(bean.hasAnyErrors());
+        assertEquals(Status.OK.getStatusCode(), response.getStatus());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class MailServerResourceTest {
         doReturn(defaultSmtpMailServer).when(mailServerManager).getDefaultSMTPMailServer();
 
         final SMTPMailServer updateSmtpMailServer = new OtherTestSmtpMailServerImpl();
-        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBean.from(updateSmtpMailServer);
+        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBeanUtil.toMailServerSmtpBean(updateSmtpMailServer);
         final Response response = mailServerResource.setMailServerSmtp(requestMailServerSmtpBean);
         final MailServerSmtpBean responseMailServerSmtpBean = (MailServerSmtpBean) response.getEntity();
 
@@ -93,7 +93,7 @@ public class MailServerResourceTest {
         verify(mailServerManager).update(smtpMailServerCaptor.capture());
         final SMTPMailServer smtpMailServer = smtpMailServerCaptor.getValue();
 
-        assertEquals(MailServerSmtpBean.from(updateSmtpMailServer), MailServerSmtpBean.from(smtpMailServer));
+        assertEquals(MailServerSmtpBeanUtil.toMailServerSmtpBean(updateSmtpMailServer),MailServerSmtpBeanUtil.toMailServerSmtpBean(smtpMailServer));
         assertEquals(requestMailServerSmtpBean, responseMailServerSmtpBean);
     }
 
@@ -103,7 +103,7 @@ public class MailServerResourceTest {
         doReturn(null).when(mailServerManager).getDefaultSMTPMailServer();
 
         final SMTPMailServer createSmtpMailServer = new DefaultTestSmtpMailServerImpl();
-        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBean.from(createSmtpMailServer);
+        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBeanUtil.toMailServerSmtpBean(createSmtpMailServer);
         final Response response = mailServerResource.setMailServerSmtp(requestMailServerSmtpBean);
         final MailServerSmtpBean responseMailServerSmtpBean = (MailServerSmtpBean) response.getEntity();
 
@@ -111,7 +111,7 @@ public class MailServerResourceTest {
         verify(mailServerManager).create(smtpMailServerCaptor.capture());
         final SMTPMailServer smtpMailServer = smtpMailServerCaptor.getValue();
 
-        assertEquals(MailServerSmtpBean.from(createSmtpMailServer), MailServerSmtpBean.from(smtpMailServer));
+        assertEquals(MailServerSmtpBeanUtil.toMailServerSmtpBean(createSmtpMailServer), MailServerSmtpBeanUtil.toMailServerSmtpBean(smtpMailServer));
         assertEquals(requestMailServerSmtpBean, responseMailServerSmtpBean);
     }
 
@@ -123,7 +123,7 @@ public class MailServerResourceTest {
         final SMTPMailServer createSmtpMailServer = new DefaultTestSmtpMailServerImpl();
         createSmtpMailServer.setPort(null);
 
-        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBean.from(createSmtpMailServer);
+        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBeanUtil.toMailServerSmtpBean(createSmtpMailServer);
         final Response response = mailServerResource.setMailServerSmtp(requestMailServerSmtpBean);
         final MailServerSmtpBean responseMailServerSmtpBean = (MailServerSmtpBean) response.getEntity();
 
@@ -142,7 +142,7 @@ public class MailServerResourceTest {
         doThrow(new MailException("SMTP test exception")).when(mailServerManager).create(any());
 
         final SMTPMailServer createSmtpMailServer = new DefaultTestSmtpMailServerImpl();
-        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBean.from(createSmtpMailServer);
+        final MailServerSmtpBean requestMailServerSmtpBean = MailServerSmtpBeanUtil.toMailServerSmtpBean(createSmtpMailServer);
         final Response response = mailServerResource.setMailServerSmtp(requestMailServerSmtpBean);
         final ErrorCollection responseErrorCollection = (ErrorCollection) response.getEntity();
 
@@ -173,10 +173,8 @@ public class MailServerResourceTest {
         doReturn(null).when(mailServerManager).getDefaultPopMailServer();
 
         final Response response = mailServerResource.getMailServerPop();
-        final ErrorCollection responseErrorCollection = (ErrorCollection) response.getEntity();
 
-        assertEquals(response.getStatus(), Status.NO_CONTENT.getStatusCode());
-        assertTrue(responseErrorCollection.hasAnyErrors());
+        assertEquals(Status.OK.getStatusCode(), response.getStatus());
     }
 
     @Test
@@ -185,7 +183,7 @@ public class MailServerResourceTest {
         doReturn(defaultPopMailServer).when(mailServerManager).getDefaultPopMailServer();
 
         final PopMailServer updatePopMailServer = new OtherTestPopMailServerImpl();
-        final MailServerPopBean requestMailServerPopBean = MailServerPopBean.from(updatePopMailServer);
+        final MailServerPopBean requestMailServerPopBean = MailServerPopBeanUtil.toMailServerPopBean(updatePopMailServer);
         final Response response = mailServerResource.setMailServerPop(requestMailServerPopBean);
         final MailServerPopBean responseMailServerPopBean = (MailServerPopBean) response.getEntity();
 
@@ -193,7 +191,7 @@ public class MailServerResourceTest {
         verify(mailServerManager).update(popMailServerCaptor.capture());
         final PopMailServer popMailServer = popMailServerCaptor.getValue();
 
-        assertEquals(MailServerPopBean.from(updatePopMailServer), MailServerPopBean.from(popMailServer));
+        assertEquals(MailServerPopBeanUtil.toMailServerPopBean(updatePopMailServer), MailServerPopBeanUtil.toMailServerPopBean(popMailServer));
         assertEquals(requestMailServerPopBean, responseMailServerPopBean);
     }
 
@@ -202,7 +200,7 @@ public class MailServerResourceTest {
         doReturn(null).when(mailServerManager).getDefaultPopMailServer();
 
         final PopMailServer createPopMailServer = new DefaultTestPopMailServerImpl();
-        final MailServerPopBean requestMailServerPopBean = MailServerPopBean.from(createPopMailServer);
+        final MailServerPopBean requestMailServerPopBean = MailServerPopBeanUtil.toMailServerPopBean(createPopMailServer);
         final Response response = mailServerResource.setMailServerPop(requestMailServerPopBean);
         final MailServerPopBean responseMailServerPopBean = (MailServerPopBean) response.getEntity();
 
@@ -210,8 +208,8 @@ public class MailServerResourceTest {
         verify(mailServerManager).create(popMailServerCaptor.capture());
         final PopMailServer popMailServer = popMailServerCaptor.getValue();
 
-        MailServerPopBean from1 = MailServerPopBean.from(createPopMailServer);
-        MailServerPopBean from2 = MailServerPopBean.from(popMailServer);
+        MailServerPopBean from1 = MailServerPopBeanUtil.toMailServerPopBean(createPopMailServer);
+        MailServerPopBean from2 = MailServerPopBeanUtil.toMailServerPopBean(popMailServer);
 
         assertEquals(from1, from2);
         assertEquals(requestMailServerPopBean, responseMailServerPopBean);
@@ -224,7 +222,7 @@ public class MailServerResourceTest {
         final PopMailServer createPopMailServer = new DefaultTestPopMailServerImpl();
         createPopMailServer.setPort(null);
 
-        final MailServerPopBean requestMailServerPopBean = MailServerPopBean.from(createPopMailServer);
+        final MailServerPopBean requestMailServerPopBean = MailServerPopBeanUtil.toMailServerPopBean(createPopMailServer);
         final Response response = mailServerResource.setMailServerPop(requestMailServerPopBean);
         final MailServerPopBean responseMailServerPopBean = (MailServerPopBean) response.getEntity();
 
@@ -242,7 +240,7 @@ public class MailServerResourceTest {
         doThrow(new MailException("POP test exception")).when(mailServerManager).create(any());
 
         final PopMailServer createPopMailServer = new DefaultTestPopMailServerImpl();
-        final MailServerPopBean requestMailServerPopBean = MailServerPopBean.from(createPopMailServer);
+        final MailServerPopBean requestMailServerPopBean = MailServerPopBeanUtil.toMailServerPopBean(createPopMailServer);
         final Response response = mailServerResource.setMailServerPop(requestMailServerPopBean);
         final ErrorCollection responseErrorCollection = (ErrorCollection) response.getEntity();
 

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
@@ -1,0 +1,135 @@
+package de.aservo.atlassian.confluence.confapi.service;
+
+import com.atlassian.applinks.api.ApplicationId;
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
+import com.atlassian.applinks.spi.manifest.ManifestNotFoundException;
+import com.atlassian.applinks.spi.util.TypeAccessor;
+import com.atlassian.confluence.settings.setup.DefaultApplicationLink;
+import com.atlassian.confluence.settings.setup.DefaultApplicationType;
+import de.aservo.atlassian.confapi.model.ApplicationLinkBean;
+import de.aservo.atlassian.confapi.model.type.ApplicationLinkTypes;
+import de.aservo.atlassian.confluence.confapi.model.DefaultAuthenticationScenario;
+import de.aservo.atlassian.confluence.confapi.model.util.ApplicationLinkBeanUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.validation.ValidationException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplicationLinkServiceTest {
+
+    @Mock
+    private MutatingApplicationLinkService mutatingApplicationLinkService;
+
+    @Mock
+    private TypeAccessor typeAccessor;
+
+    @InjectMocks
+    private ApplicationLinkServiceImpl applicationLinkService;
+
+    @Test
+    public void testDefaultDefaultAuthenticationScenarioImpl() {
+        DefaultAuthenticationScenario defaultAuthenticationScenario = new DefaultAuthenticationScenario();
+        assertTrue(defaultAuthenticationScenario.isCommonUserBase());
+        assertTrue(defaultAuthenticationScenario.isTrusted());
+    }
+
+    @Test
+    public void testGetApplicationLinks() throws URISyntaxException {
+        ApplicationLink applicationLink = createApplicationLink();
+        doReturn(Collections.singletonList(applicationLink)).when(mutatingApplicationLinkService).getApplicationLinks();
+
+        List<ApplicationLinkBean> applicationLinks = applicationLinkService.getApplicationLinks();
+
+        assertEquals(applicationLinks.get(0), ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink));
+    }
+
+    @Test
+    public void testAddApplicationLinkWithoutExistingTargetLink()
+            throws URISyntaxException, ManifestNotFoundException {
+
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+
+        doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                any(ApplicationType.class), any(ApplicationLinkDetails.class));
+        doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+
+        assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
+        assertNotEquals(applicationLinkResponse, applicationLinkBean);
+    }
+
+    @Test
+    public void testAddApplicationLinkWithExistingTargetLink() throws URISyntaxException, ManifestNotFoundException {
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+
+        doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                any(ApplicationType.class), any(ApplicationLinkDetails.class));
+        doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
+        doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+
+        assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
+        assertNotEquals(applicationLinkResponse, applicationLinkBean);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testAddApplicationLinkMissingLinkType() throws URISyntaxException {
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+        applicationLinkBean.setLinkType(null);
+
+        applicationLinkService.addApplicationLink(applicationLinkBean);
+    }
+
+    @Test
+    public void testApplicationLinkTypeConverter() throws URISyntaxException, ManifestNotFoundException {
+        for (ApplicationLinkTypes linkType : ApplicationLinkTypes.values()) {
+            ApplicationLink applicationLink = createApplicationLink();
+            ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+            applicationLinkBean.setLinkType(linkType);
+
+            doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                    any(ApplicationType.class), any(ApplicationLinkDetails.class));
+            doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+
+            ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+
+            assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
+            // TODO: assertEquals(applicationLinkResponse.getLinkType(), applicationLink.getType());
+        }
+    }
+
+    private ApplicationLinkBean createApplicationLinkBean() throws URISyntaxException {
+        ApplicationLinkBean bean = ApplicationLinkBeanUtil.toApplicationLinkBean(createApplicationLink());
+        bean.setLinkType(ApplicationLinkTypes.CROWD);
+        bean.setUsername("test");
+        bean.setPassword("test");
+        return bean;
+    }
+
+    private ApplicationLink createApplicationLink() throws URISyntaxException {
+        ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+        URI uri = new URI("http://localhost");
+        return new DefaultApplicationLink(applicationId, new DefaultApplicationType(), "test", uri, uri, false, false);
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
@@ -1,0 +1,121 @@
+package de.aservo.atlassian.confluence.confapi.service;
+
+import com.atlassian.crowd.embedded.api.CrowdDirectoryService;
+import com.atlassian.crowd.embedded.api.Directory;
+import com.atlassian.crowd.embedded.api.DirectoryType;
+import com.atlassian.crowd.exception.DirectoryCurrentlySynchronisingException;
+import com.atlassian.crowd.model.directory.ImmutableDirectory;
+import de.aservo.atlassian.confapi.exception.InternalServerErrorException;
+import de.aservo.atlassian.confapi.model.DirectoryBean;
+import de.aservo.atlassian.confluence.confapi.model.util.DirectoryBeanUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.validation.ValidationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.atlassian.crowd.directory.RemoteCrowdDirectory.*;
+import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.*;
+import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.SyncGroupMembershipsAfterAuth.WHEN_AUTHENTICATION_CREATED_THE_USER;
+import static com.atlassian.crowd.model.directory.DirectoryImpl.ATTRIBUTE_KEY_USE_NESTED_GROUPS;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DirectoryServiceTest {
+
+    @Mock
+    private CrowdDirectoryService crowdDirectoryService;
+
+    @InjectMocks
+    private DirectoryServiceImpl userDirectoryService;
+
+    @Test
+    public void testGetDirectories() {
+        Directory directory = createDirectory();
+        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
+
+        List<DirectoryBean> directories = userDirectoryService.getDirectories();
+
+        assertEquals(directories.get(0), DirectoryBeanUtil.toDirectoryBean(directory));
+    }
+
+    @Test
+    public void testSetDirectoryWithoutExistingDirectory() {
+        Directory directory = createDirectory();
+        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
+
+        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.setAppPassword("test");
+        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, false);
+
+        assertEquals(directoryAdded.getName(), directoryBean.getName());
+    }
+
+    @Test
+    public void testSetDirectoryWithExistingDirectory() {
+        Directory directory = createDirectory();
+        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
+        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
+
+        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.setAppPassword("test");
+        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, false);
+
+        assertEquals(directoryAdded.getName(), directoryBean.getName());
+    }
+
+    @Test
+    public void testSetDirectoryWithConnectionTest() {
+        Directory directory = createDirectory();
+        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
+
+        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.setAppPassword("test");
+        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, true);
+
+        assertEquals(directoryAdded.getName(), directoryBean.getName());
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testSetDirectoryInvalidBean() {
+        Directory directory = createDirectory();
+        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.setAppPassword("test");
+        directoryBean.setClientName(null);
+
+        userDirectoryService.setDirectory(directoryBean, false);
+    }
+
+    @Test(expected = InternalServerErrorException.class)
+    public void testSetDirectoryDirectoryCurrentlySynchronisingException() throws DirectoryCurrentlySynchronisingException {
+        Directory directory = createDirectory();
+        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
+        doThrow(new DirectoryCurrentlySynchronisingException(1L)).when(crowdDirectoryService).removeDirectory(1L);
+
+        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.setAppPassword("test");
+        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, false);
+    }
+
+    private Directory createDirectory() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CROWD_SERVER_URL, "http://localhost");
+        attributes.put(APPLICATION_PASSWORD, "test");
+        attributes.put(APPLICATION_NAME, "confluence-client");
+        attributes.put(CACHE_SYNCHRONISE_INTERVAL, "3600");
+        attributes.put(ATTRIBUTE_KEY_USE_NESTED_GROUPS, "false");
+        attributes.put(INCREMENTAL_SYNC_ENABLED, "true");
+        attributes.put(SYNC_GROUP_MEMBERSHIP_AFTER_SUCCESSFUL_USER_AUTH_ENABLED, WHEN_AUTHENTICATION_CREATED_THE_USER.getValue());
+        return ImmutableDirectory.builder("test", DirectoryType.CROWD, "test.class").setId(1L).setAttributes(attributes).build();
+    }
+
+}


### PR DESCRIPTION
This commit includes all remaining classes with Atlassian dependencies
which can longer reside within the confapi-commons lib. From commons
version 0.0.6 these references no longer exist and thus must be implemented
here.

Therefore, all commons classes were imported here, commons-lib reference was
updated to 0.0.6 in pom.xml and all compile errors were eliminated.