### PR TITLE
Space permissions integration tests implementation

### DIFF
--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/PermissionAnonymousAccessBean.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/PermissionAnonymousAccessBean.java
@@ -22,4 +22,12 @@ public class PermissionAnonymousAccessBean {
 
     @XmlElement
     private Boolean allowForUserProfiles;
+
+    public static final PermissionAnonymousAccessBean EXAMPLE_1;
+
+    static {
+        EXAMPLE_1 = new PermissionAnonymousAccessBean();
+        EXAMPLE_1.setAllowForPages(true);
+        EXAMPLE_1.setAllowForUserProfiles(true);
+    }
 }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceImpl.java
@@ -1,17 +1,11 @@
 package de.aservo.atlassian.confluence.confapi.rest;
 
-import com.atlassian.confluence.security.SpacePermission;
-import com.atlassian.confluence.security.SpacePermissionManager;
-import com.atlassian.confluence.security.service.AnonymousUserPermissionsService;
-import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.sun.jersey.spi.container.ResourceFilters;
 import de.aservo.atlassian.confluence.confapi.filter.AdminOnlyResourceFilter;
 import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
 import de.aservo.atlassian.confluence.confapi.rest.api.PermissionsResource;
+import de.aservo.atlassian.confluence.confapi.rest.api.PermissionsService;
 import de.aservo.confapi.commons.constants.ConfAPI;
-import de.aservo.confapi.commons.model.ErrorCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -20,92 +14,28 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.List;
 
-import static com.atlassian.confluence.security.SpacePermission.BROWSE_USERS_PERMISSION;
-import static com.atlassian.confluence.security.SpacePermission.USE_CONFLUENCE_PERMISSION;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-
-/**
- * The type Global permissions resource.
- */
 @Path(ConfAPI.PERMISSIONS)
 @Produces(MediaType.APPLICATION_JSON)
 @ResourceFilters(AdminOnlyResourceFilter.class)
 @Component
 public class PermissionsResourceImpl implements PermissionsResource {
 
-    private static final Logger log = LoggerFactory.getLogger(PermissionsResourceImpl.class);
+    private final PermissionsService permissionsService;
 
-    private final AnonymousUserPermissionsService anonymousUserPermissionsService;
-    private final SpacePermissionManager spacePermissionManager;
-
-    /**
-     * Instantiates a new Global permissions resource.
-     *
-     * @param anonymousUserPermissionsService the anonymous user permissions service
-     */
     @Inject
-    public PermissionsResourceImpl(@ComponentImport AnonymousUserPermissionsService anonymousUserPermissionsService,
-                               @ComponentImport SpacePermissionManager spacePermissionManager) {
-        this.anonymousUserPermissionsService = anonymousUserPermissionsService;
-        this.spacePermissionManager = spacePermissionManager;
+    public PermissionsResourceImpl(PermissionsService permissionsService) {
+        this.permissionsService = permissionsService;
     }
 
-    /**
-     * Gets the global access permissions.
-     *
-     * @return the global access permissions
-     */
     @Override
     public Response getPermissionAnonymousAccess() {
-        final ErrorCollection errorCollection = new ErrorCollection();
-        try {
-            List<SpacePermission> globalPermissions = spacePermissionManager.getGlobalPermissions();
-            PermissionAnonymousAccessBean accessBean = new PermissionAnonymousAccessBean();
-            accessBean.setAllowForPages(containsAnonymousPermission(globalPermissions, USE_CONFLUENCE_PERMISSION));
-            accessBean.setAllowForUserProfiles(containsAnonymousPermission(globalPermissions, BROWSE_USERS_PERMISSION));
-            return Response.ok(accessBean).build();
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            errorCollection.addErrorMessage(e.getMessage());
-        }
-        return Response.status(BAD_REQUEST).entity(errorCollection).build();
+        return Response.ok(permissionsService.getPermissionAnonymousAccess()).build();
     }
 
-    /**
-     * Sets global access permissions.
-     *
-     * @param accessBean          bean describing the anonymous access
-     * @return the global access permissions
-     */
     @Override
     public Response setPermissionAnonymousAccess(
             @NotNull final PermissionAnonymousAccessBean accessBean) {
-
-        final ErrorCollection errorCollection = new ErrorCollection();
-        try {
-            if (accessBean.getAllowForPages() != null) {
-                anonymousUserPermissionsService.setUsePermission(accessBean.getAllowForPages());
-            }
-            if (accessBean.getAllowForUserProfiles() != null) {
-                anonymousUserPermissionsService.setViewUserProfilesPermission(accessBean.getAllowForUserProfiles());
-            }
-            return getPermissionAnonymousAccess();
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            errorCollection.addErrorMessage(e.getMessage());
-        }
-        return Response.status(BAD_REQUEST).entity(errorCollection).build();
+        return Response.ok(permissionsService.setPermissionAnonymousAccess(accessBean)).build();
     }
-
-    private boolean containsAnonymousPermission(List<SpacePermission> permissions, String permissionType) {
-        for (SpacePermission permission : permissions) {
-            if (permission.getType().equals(permissionType) && permission.getGroup() == null) {
-                return true;
-            }
-        }
-        return false;
-    }
-
 }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/rest/api/PermissionsService.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/rest/api/PermissionsService.java
@@ -1,0 +1,23 @@
+package de.aservo.atlassian.confluence.confapi.rest.api;
+
+import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
+
+import javax.validation.constraints.NotNull;
+
+public interface PermissionsService {
+
+    /**
+     * Returns the currently configured anonymous access permissions
+     *
+     * @return
+     */
+    PermissionAnonymousAccessBean getPermissionAnonymousAccess();
+
+    /**
+     * Sets the anonymous access permissions
+     *
+     * @param accessBean - the config to set
+     * @return the updated anonymous access permissions
+     */
+    PermissionAnonymousAccessBean setPermissionAnonymousAccess(@NotNull PermissionAnonymousAccessBean accessBean);
+}

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/PermissionsServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/PermissionsServiceImpl.java
@@ -1,0 +1,61 @@
+package de.aservo.atlassian.confluence.confapi.service;
+
+import com.atlassian.confluence.security.SpacePermission;
+import com.atlassian.confluence.security.SpacePermissionManager;
+import com.atlassian.confluence.security.service.AnonymousUserPermissionsService;
+import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
+import de.aservo.atlassian.confluence.confapi.rest.api.PermissionsService;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static com.atlassian.confluence.security.SpacePermission.BROWSE_USERS_PERMISSION;
+import static com.atlassian.confluence.security.SpacePermission.USE_CONFLUENCE_PERMISSION;
+
+@Component
+@ExportAsService(PermissionsService.class)
+public class PermissionsServiceImpl implements PermissionsService {
+
+    private final AnonymousUserPermissionsService anonymousUserPermissionsService;
+    private final SpacePermissionManager spacePermissionManager;
+
+    @Inject
+    public PermissionsServiceImpl(
+            @ComponentImport AnonymousUserPermissionsService anonymousUserPermissionsService,
+            @ComponentImport SpacePermissionManager spacePermissionManager) {
+        this.anonymousUserPermissionsService = anonymousUserPermissionsService;
+        this.spacePermissionManager = spacePermissionManager;
+    }
+
+    @Override
+    public PermissionAnonymousAccessBean getPermissionAnonymousAccess() {
+        List<SpacePermission> globalPermissions = spacePermissionManager.getGlobalPermissions();
+        PermissionAnonymousAccessBean accessBean = new PermissionAnonymousAccessBean();
+        accessBean.setAllowForPages(containsAnonymousPermission(globalPermissions, USE_CONFLUENCE_PERMISSION));
+        accessBean.setAllowForUserProfiles(containsAnonymousPermission(globalPermissions, BROWSE_USERS_PERMISSION));
+        return accessBean;
+    }
+
+    @Override
+    public PermissionAnonymousAccessBean setPermissionAnonymousAccess(PermissionAnonymousAccessBean accessBean) {
+        if (accessBean.getAllowForPages() != null) {
+            anonymousUserPermissionsService.setUsePermission(accessBean.getAllowForPages());
+        }
+        if (accessBean.getAllowForUserProfiles() != null) {
+            anonymousUserPermissionsService.setViewUserProfilesPermission(accessBean.getAllowForUserProfiles());
+        }
+        return getPermissionAnonymousAccess();
+    }
+
+    private boolean containsAnonymousPermission(List<SpacePermission> permissions, String permissionType) {
+        for (SpacePermission permission : permissions) {
+            if (permission.getType().equals(permissionType) && permission.getGroup() == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
@@ -1,10 +1,7 @@
 package de.aservo.atlassian.confluence.confapi.rest;
 
-import com.atlassian.confluence.security.SpacePermission;
-import com.atlassian.confluence.security.SpacePermissionManager;
-import com.atlassian.confluence.security.service.AnonymousUserPermissionsService;
 import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
-import de.aservo.confapi.commons.model.ErrorCollection;
+import de.aservo.atlassian.confluence.confapi.rest.api.PermissionsService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,13 +9,9 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
 
-import static com.atlassian.confluence.security.SpacePermission.USE_CONFLUENCE_PERMISSION;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PermissionsResourceTest {
@@ -26,60 +19,29 @@ public class PermissionsResourceTest {
     private PermissionsResourceImpl resource;
 
     @Mock
-    private AnonymousUserPermissionsService anonymousUserPermissionsService;
-
-    @Mock
-    private SpacePermissionManager spacePermissionManager;
+    private PermissionsService permissionsService;
 
     @Before
     public void setup() {
-        resource = new PermissionsResourceImpl(anonymousUserPermissionsService, spacePermissionManager);
+        resource = new PermissionsResourceImpl(permissionsService);
     }
 
     @Test
     public void testGetAnonymousPermissions() {
-        List<SpacePermission> globalPermissions = new ArrayList<>();
-        globalPermissions.add(SpacePermission.createGroupSpacePermission(USE_CONFLUENCE_PERMISSION, null, null));
-
-        doReturn(globalPermissions).when(spacePermissionManager).getGlobalPermissions();
+        doReturn(PermissionAnonymousAccessBean.EXAMPLE_1).when(permissionsService).getPermissionAnonymousAccess();
 
         Response response = resource.getPermissionAnonymousAccess();
         assertEquals(200, response.getStatus());
         assertEquals(PermissionAnonymousAccessBean.class, response.getEntity().getClass());
 
         PermissionAnonymousAccessBean accessBean = (PermissionAnonymousAccessBean)response.getEntity();
-        assertTrue(accessBean.getAllowForPages());
-        assertFalse(accessBean.getAllowForUserProfiles());
-    }
-
-    @Test
-    public void testGetAnonymousPermissionsWithError() {
-        doThrow(new RuntimeException()).when(spacePermissionManager).getGlobalPermissions();
-
-        Response response = resource.getPermissionAnonymousAccess();
-        assertEquals(400, response.getStatus());
-
-        assertNotNull(response.getEntity());
-        assertEquals(ErrorCollection.class, response.getEntity().getClass());
+        assertEquals(PermissionAnonymousAccessBean.EXAMPLE_1, accessBean);
     }
 
     @Test
     public void testSetAnonymousPermissions() {
-        PermissionAnonymousAccessBean accessBean = new PermissionAnonymousAccessBean(true, true);
-        Response response = resource.setPermissionAnonymousAccess(accessBean);
+        doReturn(PermissionAnonymousAccessBean.EXAMPLE_1).when(permissionsService).getPermissionAnonymousAccess();
+        Response response = resource.setPermissionAnonymousAccess(PermissionAnonymousAccessBean.EXAMPLE_1);
         assertEquals(200, response.getStatus());
-        assertEquals(PermissionAnonymousAccessBean.class, response.getEntity().getClass());
-    }
-
-    @Test
-    public void testSetAnonymousPermissionsWithError() {
-        doThrow(new RuntimeException()).when(anonymousUserPermissionsService).setUsePermission(true);
-
-        PermissionAnonymousAccessBean accessBean = new PermissionAnonymousAccessBean(true, true);
-        Response response = resource.setPermissionAnonymousAccess(accessBean);
-        assertEquals(400, response.getStatus());
-
-        assertNotNull(response.getEntity());
-        assertEquals(ErrorCollection.class, response.getEntity().getClass());
     }
 }

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/PermissionsServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/PermissionsServiceTest.java
@@ -1,0 +1,53 @@
+package de.aservo.atlassian.confluence.confapi.service;
+
+import com.atlassian.confluence.security.SpacePermission;
+import com.atlassian.confluence.security.SpacePermissionManager;
+import com.atlassian.confluence.security.service.AnonymousUserPermissionsService;
+import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.atlassian.confluence.security.SpacePermission.USE_CONFLUENCE_PERMISSION;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PermissionsServiceTest {
+
+    @Mock
+    private AnonymousUserPermissionsService anonymousUserPermissionsService;
+
+    @Mock
+    private SpacePermissionManager spacePermissionManager;
+
+    private PermissionsServiceImpl permissionsService;
+
+    @Before
+    public void setup() {
+        permissionsService = new PermissionsServiceImpl(anonymousUserPermissionsService, spacePermissionManager);
+    }
+
+    @Test
+    public void testGetAnonymousPermissions() {
+        List<SpacePermission> globalPermissions = new ArrayList<>();
+        globalPermissions.add(SpacePermission.createGroupSpacePermission(USE_CONFLUENCE_PERMISSION, null, null));
+
+        doReturn(globalPermissions).when(spacePermissionManager).getGlobalPermissions();
+
+        PermissionAnonymousAccessBean response = permissionsService.getPermissionAnonymousAccess();
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testSetAnonymousPermissions() {
+        PermissionAnonymousAccessBean accessBean = new PermissionAnonymousAccessBean(true, true);
+        PermissionAnonymousAccessBean response = permissionsService.setPermissionAnonymousAccess(accessBean);
+        assertNotNull(response);
+    }
+}

--- a/src/test/java/it/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
@@ -1,0 +1,84 @@
+package it.de.aservo.atlassian.confluence.confapi.rest;
+
+import de.aservo.atlassian.confluence.confapi.model.PermissionAnonymousAccessBean;
+import de.aservo.confapi.commons.constants.ConfAPI;
+import it.de.aservo.confapi.commons.rest.ResourceBuilder;
+import org.apache.wink.client.ClientAuthenticationException;
+import org.apache.wink.client.ClientResponse;
+import org.apache.wink.client.Resource;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class PermissionsResourceTest {
+
+    @Test
+    public void testGetAnonymousPermissions() {
+        Resource permissionsResource = ResourceBuilder.builder(ConfAPI.PERMISSIONS + "/" + ConfAPI.PERMISSION_ANONYMOUS_ACCESS).build();
+
+        ClientResponse clientResponse = permissionsResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+
+        PermissionAnonymousAccessBean accessBean = clientResponse.getEntity(PermissionAnonymousAccessBean.class);
+        assertNotNull(accessBean);
+    }
+
+    @Test
+    public void testSetAnonymousPermissions() {
+        Resource permissionsResource = ResourceBuilder.builder(ConfAPI.PERMISSIONS + "/" + ConfAPI.PERMISSION_ANONYMOUS_ACCESS).build();
+
+        ClientResponse clientResponse = permissionsResource.put(getExampleBean());
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+
+        PermissionAnonymousAccessBean accessBean = clientResponse.getEntity(PermissionAnonymousAccessBean.class);
+        assertEquals(getExampleBean(), accessBean);
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testGetAnonymousPermissionsUnauthenticated() {
+        Resource permissionsResource = ResourceBuilder.builder(ConfAPI.PERMISSIONS + "/" + ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
+                .username("wrong")
+                .password("password")
+                .build();
+        permissionsResource.get();
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testSetAnonymousPermissionsUnauthenticated() {
+        Resource permissionsResource = ResourceBuilder.builder(ConfAPI.PERMISSIONS + "/" + ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
+                .username("wrong")
+                .password("password")
+                .build();
+        permissionsResource.put(getExampleBean());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testGetAnonymousPermissionsUnauthorized() {
+        Resource permissionsResource = ResourceBuilder.builder(ConfAPI.PERMISSIONS + "/" + ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
+                .username("user")
+                .password("user")
+                .build();
+        permissionsResource.get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), permissionsResource.put(getExampleBean()).getStatusCode());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testSetAnonymousPermissionsUnauthorized() {
+        Resource permissionsResource = ResourceBuilder.builder(ConfAPI.PERMISSIONS + "/" + ConfAPI.PERMISSION_ANONYMOUS_ACCESS)
+                .username("user")
+                .password("user")
+                .build();
+        permissionsResource.put(getExampleBean());
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), permissionsResource.put(getExampleBean()).getStatusCode());
+    }
+
+    protected PermissionAnonymousAccessBean getExampleBean() {
+        return PermissionAnonymousAccessBean.EXAMPLE_1;
+    }
+}


### PR DESCRIPTION
This commit implements space permissions integration tests. Note that these
tests have no abstract counterpart in the commons-lib because other Atlassian
products do not share the ability to manage spaces.

In accordance with the current service interface achitecture implemented in the
commons lib the permissions resource was refactored to represent permission
interface and resource consumer as well. Thus, this implementation is future proof
when further abstraction might be necessary.

Finally, a bean example wor permission access was added for generic test use.