### PR TITLE
Update Confluence Version to 7.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   maven:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     resource_class: large
     working_directory: /tmp/build
 
@@ -16,7 +16,7 @@ jobs:
           key: confapi-plugin-{{ checksum "pom.xml" }}
       - run:
           name: Download Dependencies
-          command: ./mvnw dependency:go-offline -U
+          command: ./mvnw dependency:go-offline -U -B
       - run:
           name: Compile and Package
           command: ./mvnw package -DskipTests
@@ -58,7 +58,7 @@ jobs:
           key: confapi-plugin-{{ checksum "pom.xml" }}
       - run:
           name: Run Integration Tests
-          command: ./mvnw integration-test -DskipUnitTests
+          command: ./mvnw integration-test -DskipUnitTests -B
       - save_cache:
           paths:
             - ~/.m2
@@ -78,7 +78,7 @@ jobs:
           command: gpg --no-tty --batch --import .circleci/sign.asc
       - run:
           name: Deploy to Maven Central
-          command: export GPG_TTY=$(tty) && ./mvnw deploy -DskipTests -s .circleci/settings.xml
+          command: export GPG_TTY=$(tty) && ./mvnw deploy -DskipTests -s .circleci/settings.xml -B
       - save_cache:
           paths:
             - ~/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </developers>
 
     <properties>
-        <confluence.version>6.15.10</confluence.version>
+        <confluence.version>7.5.0</confluence.version>
         <!-- other properties -->
         <ajp.port>8109</ajp.port>
         <amps.version>8.0.2</amps.version>
@@ -63,6 +63,7 @@
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
         <confapi-commons.version>0.0.9-SNAPSHOT</confapi-commons.version>
+        <javax.el-api.version>3.0.0</javax.el-api.version>
         <log4j.version>2.8.2</log4j.version>
         <openapi-generator-maven-plugin.version>4.3.0</openapi-generator-maven-plugin.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
@@ -229,7 +230,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -254,6 +255,7 @@
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
+            <version>${javax.el-api.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -320,13 +322,10 @@
                     <!-- https://developer.atlassian.com/docs/advanced-topics/configuration-of-instructions-in-atlassian-plugins -->
                     <instructions>
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
-                        <!-- Add package to export here -->
-                        <Export-Package/>
-                        <!-- Add package import here -->
                         <Import-Package>
                             *;version="0";resolution:=optional
                         </Import-Package>
-                        <!-- Ensure plugin is spring powered -->
+                        <Export-Package/>
                         <Spring-Context>*</Spring-Context>
                     </instructions>
                 </configuration>
@@ -352,15 +351,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <scannedDependencies>
-                        <dependency>
-                            <groupId>com.atlassian.plugin</groupId>
-                            <artifactId>atlassian-spring-scanner-external-jar</artifactId>
-                        </dependency>
-                    </scannedDependencies>
-                    <verbose>true</verbose>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,11 @@
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
         <confapi-commons.version>0.0.9-SNAPSHOT</confapi-commons.version>
+        <log4j.version>2.8.2</log4j.version>
         <openapi-generator-maven-plugin.version>4.3.0</openapi-generator-maven-plugin.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <powermock-api-easymock.version>2.0.5</powermock-api-easymock.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -279,6 +281,20 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock-api-easymock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.atlassian.com/schema/atlassian-scanner
-        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
 </beans>

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/type/DefaultAuthenticationScenarioTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/type/DefaultAuthenticationScenarioTest.java
@@ -3,7 +3,7 @@ package de.aservo.atlassian.confluence.confapi.model.type;
 import de.aservo.atlassian.confluence.confapi.model.DefaultAuthenticationScenario;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/ApplicationLinkBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/ApplicationLinkBeanUtilTest.java
@@ -18,7 +18,7 @@ import de.aservo.confapi.commons.model.type.ApplicationLinkTypes;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
@@ -6,7 +6,7 @@ import com.atlassian.crowd.model.directory.DirectoryImpl;
 import de.aservo.confapi.commons.model.DirectoryBean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Map;
 

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/LicenseBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/LicenseBeanUtilTest.java
@@ -4,7 +4,7 @@ import com.atlassian.sal.api.license.SingleProductLicenseDetailsView;
 import de.aservo.confapi.commons.model.LicenseBean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerPopBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerPopBeanUtilTest.java
@@ -5,7 +5,7 @@ import com.atlassian.mail.server.PopMailServer;
 import de.aservo.confapi.commons.model.MailServerPopBean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerSmtpBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/MailServerSmtpBeanUtilTest.java
@@ -5,7 +5,7 @@ import com.atlassian.mail.server.SMTPMailServer;
 import de.aservo.confapi.commons.model.MailServerSmtpBean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.core.Response;
 

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/rest/PermissionsResourceTest.java
@@ -40,7 +40,6 @@ public class PermissionsResourceTest {
 
     @Test
     public void testSetAnonymousPermissions() {
-        doReturn(PermissionAnonymousAccessBean.EXAMPLE_1).when(permissionsService).getPermissionAnonymousAccess();
         Response response = resource.setPermissionAnonymousAccess(PermissionAnonymousAccessBean.EXAMPLE_1);
         assertEquals(200, response.getStatus());
     }

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
@@ -14,9 +14,9 @@ import de.aservo.atlassian.confluence.confapi.model.util.ApplicationLinkBeanUtil
 import de.aservo.confapi.commons.model.ApplicationLinkBean;
 import de.aservo.confapi.commons.model.ApplicationLinksBean;
 import de.aservo.confapi.commons.model.type.ApplicationLinkTypes;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -39,8 +39,12 @@ public class ApplicationLinkServiceTest {
     @Mock
     private TypeAccessor typeAccessor;
 
-    @InjectMocks
     private ApplicationLinkServiceImpl applicationLinkService;
+
+    @Before
+    public void setup() {
+        applicationLinkService = new ApplicationLinkServiceImpl(mutatingApplicationLinkService, typeAccessor);
+    }
 
     @Test
     public void testDefaultDefaultAuthenticationScenarioImpl() {

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.validation.ValidationException;
 import java.net.URI;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
@@ -8,9 +8,9 @@ import com.atlassian.crowd.model.directory.ImmutableDirectory;
 import de.aservo.atlassian.confluence.confapi.model.util.DirectoryBeanUtil;
 import de.aservo.confapi.commons.exception.InternalServerErrorException;
 import de.aservo.confapi.commons.model.DirectoryBean;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -35,15 +35,19 @@ public class DirectoryServiceTest {
     @Mock
     private CrowdDirectoryService crowdDirectoryService;
 
-    @InjectMocks
-    private DirectoryServiceImpl userDirectoryService;
+    private DirectoryServiceImpl directoryService;
+
+    @Before
+    public void setup() {
+        directoryService = new DirectoryServiceImpl(crowdDirectoryService);
+    }
 
     @Test
     public void testGetDirectories() {
         Directory directory = createDirectory();
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
 
-        List<DirectoryBean> directories = userDirectoryService.getDirectories();
+        List<DirectoryBean> directories = directoryService.getDirectories();
 
         assertEquals(directories.get(0), DirectoryBeanUtil.toDirectoryBean(directory));
     }
@@ -55,7 +59,7 @@ public class DirectoryServiceTest {
 
         DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
         directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, false);
+        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, false);
 
         assertEquals(directoryAdded.getName(), directoryBean.getName());
     }
@@ -68,7 +72,7 @@ public class DirectoryServiceTest {
 
         DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
         directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, false);
+        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, false);
 
         assertEquals(directoryAdded.getName(), directoryBean.getName());
     }
@@ -80,7 +84,7 @@ public class DirectoryServiceTest {
 
         DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
         directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, true);
+        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, true);
 
         assertEquals(directoryAdded.getName(), directoryBean.getName());
     }
@@ -92,7 +96,7 @@ public class DirectoryServiceTest {
         directoryBean.setAppPassword("test");
         directoryBean.setClientName(null);
 
-        userDirectoryService.setDirectory(directoryBean, false);
+        directoryService.setDirectory(directoryBean, false);
     }
 
     @Test(expected = InternalServerErrorException.class)
@@ -103,7 +107,7 @@ public class DirectoryServiceTest {
 
         DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
         directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = userDirectoryService.setDirectory(directoryBean, false);
+        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, false);
     }
 
     private Directory createDirectory() {

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.validation.ValidationException;
 import java.util.Collections;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.atlassian.confluence.setup.ConfluenceBootstrapConstants.DEFAULT_LICENSE_REGISTRY_KEY;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceTest.java
@@ -69,7 +69,6 @@ public class LicensesServiceTest {
     public void testSetLicense() {
         LicenseBean licenseBean = LicenseBean.EXAMPLE_1;
         DefaultSingleProductLicenseDetailsView testLicense = new DefaultSingleProductLicenseDetailsView(licenseBean);
-        doReturn(false).when(licenseHandler).hostAllowsMultipleLicenses();
         doReturn(testLicense).when(licenseHandler).getProductLicenseDetails(DEFAULT_LICENSE_REGISTRY_KEY);
 
         LicensesBean updatedLicensesBean = licenseService.setLicense(licenseBean);
@@ -80,10 +79,7 @@ public class LicensesServiceTest {
     @Test(expected = BadRequestException.class)
     public void testSetLicenseWithError() throws InvalidOperationException {
         LicenseBean licenseBean = LicenseBean.EXAMPLE_1;
-        DefaultSingleProductLicenseDetailsView testLicense = new DefaultSingleProductLicenseDetailsView(licenseBean);
-        doReturn(false).when(licenseHandler).hostAllowsMultipleLicenses();
-        doReturn(testLicense).when(licenseHandler).getProductLicenseDetails(DEFAULT_LICENSE_REGISTRY_KEY);
-        doThrow(new InvalidOperationException("", "")).when(licenseHandler).addProductLicense(any(String.class), any(String.class));
+        doThrow(new InvalidOperationException("", "")).when(licenseHandler).addProductLicense(any(), any());
 
         licenseService.setLicense(licenseBean);
     }

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/MailServerServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/MailServerServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/MailServerServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/MailServerServiceTest.java
@@ -41,7 +41,6 @@ public class MailServerServiceTest {
     @Test
     public void testGetSmtpMailServer() {
         final SMTPMailServer smtpMailServer = new DefaultTestSmtpMailServerImpl();
-        doReturn(true).when(mailServerManager).isDefaultSMTPMailServerDefined();
         doReturn(smtpMailServer).when(mailServerManager).getDefaultSMTPMailServer();
 
         final MailServerSmtpBean bean = mailServerService.getMailServerSmtp();
@@ -114,7 +113,6 @@ public class MailServerServiceTest {
     @Test (expected = BadRequestException.class)
     public void testPutSmtpMaiLServerException() throws Exception {
         doReturn(false).when(mailServerManager).isDefaultSMTPMailServerDefined();
-        doReturn(null).when(mailServerManager).getDefaultSMTPMailServer();
         doThrow(new MailException("SMTP test exception")).when(mailServerManager).create(any());
 
         final SMTPMailServer createSmtpMailServer = new DefaultTestSmtpMailServerImpl();

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/PermissionsServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/PermissionsServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/SettingsServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/SettingsServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/UserServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/UserServiceTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static de.aservo.atlassian.confluence.confapi.model.util.UserBeanUtil.toUser;
 import static de.aservo.atlassian.confluence.confapi.model.util.UserBeanUtil.toUserBean;


### PR DESCRIPTION
Improve and clean up unit tests
    
    This commit adds log4j and slf4j dependencies needed for proper logging in unit
    tests. Unnecessary mockings are removed as the updated Mockito in a follow-up
    commit will throw exceptions in these cases. Two remaining `@InjectMocks` have
    been replaced by manual dependency injection via constructor. The
    `userDirectoryService` has been renamed to `directoryService` in order to match
    the class name.
    
Upgrade Confluence version to 7.5, fix Spring scanning and tests
    
    Confluence has been updates to 7.5 as the master branch should always use the
    latest version. Some dependencies have been updates in order to match the
    dependencies used by that new version. The Spring scanner configuration has been
    fixed for that new version too.
    
    The new Mockito version offers a new `MockitoJUnitRunner`, the deprecated one
    has been replaced in all classes in order to make the tests run again.

Use Java 11 and Maven --batch option in Circle CI