### PR TITLE
DirectoryBean abstraction implementation

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -70,6 +70,19 @@ Upon successful request, returns the added `ApplicationLinkBean` object
 
 
 
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| ignore-setup-errors 
+|   
+| - 
+| false 
+|  
+
+|===         
 
 
 ===== Return Type
@@ -231,6 +244,19 @@ Upon successful request, returns a `ApplicationLinksBean` object containing all 
 
 
 
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| ignore-setup-errors 
+|   
+| - 
+| false 
+|  
+
+|===         
 
 
 ===== Return Type
@@ -2448,6 +2474,18 @@ endif::internal-generation[]
 |===         
 | Field Name| Required| Type| Description| Format
 
+| host 
+|  
+| String  
+| 
+|  
+
+| port 
+|  
+| Integer  
+| 
+| int32 
+
 | username 
 |  
 | String  
@@ -2459,12 +2497,6 @@ endif::internal-generation[]
 | String  
 | 
 |  
-
-| uri 
-|  
-| URI  
-| 
-| uri 
 
 |===
 

--- a/index.adoc
+++ b/index.adoc
@@ -44,7 +44,7 @@ Add a single application link
 
 ===== Description 
 
-Upon successful request, returns a `ApplicationLinksBean` object containing all application links
+Upon successful request, returns the added `ApplicationLinkBean` object
 
 
 // markup not found, no include::{specDir}application-links/POST/spec.adoc[opts=optional]
@@ -74,7 +74,7 @@ Upon successful request, returns a `ApplicationLinksBean` object containing all 
 
 ===== Return Type
 
-<<ApplicationLinksBean>>
+<<ApplicationLinkBean>>
 
 
 ===== Content Type
@@ -91,7 +91,7 @@ Upon successful request, returns a `ApplicationLinksBean` object containing all 
 
 | 200
 | 
-|  <<ApplicationLinksBean>>
+|  <<ApplicationLinkBean>>
 
 
 | 0
@@ -287,6 +287,106 @@ endif::internal-generation[]
 === Directories
 
 
+[.addDirectory]
+==== addDirectory
+    
+`POST /directories`
+
+Adds a new directory
+
+===== Description 
+
+Adds a new user directory to the existing list of directories
+
+
+// markup not found, no include::{specDir}directories/POST/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+
+===== Body Parameter
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| AbstractDirectoryBean 
+|  <<AbstractDirectoryBean>> 
+| X 
+|  
+|  
+
+|===         
+
+
+
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| test-connection 
+|   
+| - 
+| false 
+|  
+
+|===         
+
+
+===== Return Type
+
+<<AbstractDirectoryBean>>
+
+
+===== Content Type
+
+* application/json
+
+===== Responses
+
+.http response codes
+[cols="2,3,1"]
+|===         
+| Code | Message | Datatype 
+
+
+| 200
+| 
+|  <<AbstractDirectoryBean>>
+
+
+| 0
+| 
+|  <<ErrorCollection>>
+
+|===         
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}directories/POST/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}directories/POST/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :directories/POST/POST.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}directories/POST/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
 [.getDirectories]
 ==== getDirectories
     
@@ -361,16 +461,16 @@ ifdef::internal-generation[]
 endif::internal-generation[]
 
 
-[.setDirectory]
-==== setDirectory
+[.setDirectories]
+==== setDirectories
     
 `PUT /directories`
 
-Set a new directory
+Set a new list of directories
 
 ===== Description 
 
-Any existing directory with the same name will be removed before adding the new one
+Any existing directories with the same names will be removed before adding the new ones
 
 
 // markup not found, no include::{specDir}directories/PUT/spec.adoc[opts=optional]
@@ -386,8 +486,8 @@ Any existing directory with the same name will be removed before adding the new 
 |===         
 |Name| Description| Required| Default| Pattern
 
-| DirectoryBean 
-|  <<DirectoryBean>> 
+| DirectoriesBean 
+|  <<DirectoriesBean>> 
 | X 
 |  
 |  
@@ -413,7 +513,7 @@ Any existing directory with the same name will be removed before adding the new 
 
 ===== Return Type
 
-<<DirectoryBean>>
+<<DirectoriesBean>>
 
 
 ===== Content Type
@@ -430,7 +530,7 @@ Any existing directory with the same name will be removed before adding the new 
 
 | 200
 | 
-|  <<DirectoryBean>>
+|  <<DirectoriesBean>>
 
 
 | 0
@@ -474,7 +574,7 @@ Adds a single gadget
 
 ===== Description 
 
-Upon successful request, returns a `GadgetsBean` object containing gadgets details
+Upon successful request, returns the added `GadgetBean` object containing gadget details
 
 
 // markup not found, no include::{specDir}gadgets/POST/spec.adoc[opts=optional]
@@ -504,7 +604,7 @@ Upon successful request, returns a `GadgetsBean` object containing gadgets detai
 
 ===== Return Type
 
-<<GadgetsBean>>
+<<GadgetBean>>
 
 
 ===== Content Type
@@ -521,7 +621,7 @@ Upon successful request, returns a `GadgetsBean` object containing gadgets detai
 
 | 200
 | 
-|  <<GadgetsBean>>
+|  <<GadgetBean>>
 
 
 | 0
@@ -726,7 +826,7 @@ Adds a single license
 
 ===== Description 
 
-Upon successful request, returns a `LicensesBean` object containing license details
+Upon successful request, returns the added `LicenseBean` object containing license details
 
 
 // markup not found, no include::{specDir}licenses/POST/spec.adoc[opts=optional]
@@ -756,7 +856,7 @@ Upon successful request, returns a `LicensesBean` object containing license deta
 
 ===== Return Type
 
-<<LicensesBean>>
+<<LicenseBean>>
 
 
 ===== Content Type
@@ -773,7 +873,7 @@ Upon successful request, returns a `LicensesBean` object containing license deta
 
 | 200
 | 
-|  <<LicensesBean>>
+|  <<LicenseBean>>
 
 
 | 0
@@ -813,7 +913,7 @@ Get all licenses information
 
 ===== Description 
 
-Upon successful request, returns a `LicensesBean` object containing license details
+Upon successful request, returns a `LicensesBean` object containing license details. Be aware that `products` collection of the `LicenseBean` contains the product display names, not the product key names
 
 
 // markup not found, no include::{specDir}licenses/GET/spec.adoc[opts=optional]
@@ -1796,6 +1896,106 @@ ifdef::internal-generation[]
 endif::internal-generation[]
 
 
+[.setUser]
+==== setUser
+    
+`PUT /users`
+
+Updates user details
+
+===== Description 
+
+Upon successful request, returns the updated `UserBean` object (user name cannot be updated)
+
+
+// markup not found, no include::{specDir}users/PUT/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+
+===== Body Parameter
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| UserBean 
+|  <<UserBean>> 
+| X 
+|  
+|  
+
+|===         
+
+
+
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| userName 
+|   
+| X 
+| null 
+|  
+
+|===         
+
+
+===== Return Type
+
+<<UserBean>>
+
+
+===== Content Type
+
+* application/json
+
+===== Responses
+
+.http response codes
+[cols="2,3,1"]
+|===         
+| Code | Message | Datatype 
+
+
+| 200
+| 
+|  <<UserBean>>
+
+
+| 0
+| 
+|  <<ErrorCollection>>
+
+|===         
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}users/PUT/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}users/PUT/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :users/PUT/PUT.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}users/PUT/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
 [.setUserPassword]
 ==== setUserPassword
     
@@ -1896,108 +2096,75 @@ ifdef::internal-generation[]
 endif::internal-generation[]
 
 
-[.updateUser]
-==== updateUser
-    
-`PUT /users`
-
-Updates user details
-
-===== Description 
-
-Upon successful request, returns the updated `UserBean` object (user name cannot be updated)
-
-
-// markup not found, no include::{specDir}users/PUT/spec.adoc[opts=optional]
-
-
-
-===== Parameters
-
-
-===== Body Parameter
-
-[cols="2,3,1,1,1"]
-|===         
-|Name| Description| Required| Default| Pattern
-
-| UserBean 
-|  <<UserBean>> 
-| X 
-|  
-|  
-
-|===         
-
-
-
-====== Query Parameters
-
-[cols="2,3,1,1,1"]
-|===         
-|Name| Description| Required| Default| Pattern
-
-| userName 
-|   
-| X 
-| null 
-|  
-
-|===         
-
-
-===== Return Type
-
-<<UserBean>>
-
-
-===== Content Type
-
-* application/json
-
-===== Responses
-
-.http response codes
-[cols="2,3,1"]
-|===         
-| Code | Message | Datatype 
-
-
-| 200
-| 
-|  <<UserBean>>
-
-
-| 0
-| 
-|  <<ErrorCollection>>
-
-|===         
-
-===== Samples
-
-
-// markup not found, no include::{snippetDir}users/PUT/http-request.adoc[opts=optional]
-
-
-// markup not found, no include::{snippetDir}users/PUT/http-response.adoc[opts=optional]
-
-
-
-// file not found, no * wiremock data link :users/PUT/PUT.json[]
-
-
-ifdef::internal-generation[]
-===== Implementation
-
-// markup not found, no include::{specDir}users/PUT/implementation.adoc[opts=optional]
-
-
-endif::internal-generation[]
-
-
 [#models]
 == Models
+
+
+[#AbstractDirectoryBean]
+=== _AbstractDirectoryBean_ 
+
+
+
+[.fields-AbstractDirectoryBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| id 
+|  
+| Long  
+| 
+| int64 
+
+| name 
+| X 
+| String  
+| 
+|  
+
+| description 
+|  
+| String  
+| 
+|  
+
+| active 
+|  
+| Boolean  
+| 
+|  
+
+| server 
+|  
+| DirectoryLdapServer  
+| 
+|  
+
+| permissions 
+|  
+| DirectoryLdapPermissions  
+| 
+|  
+
+| advanced 
+|  
+| DirectoryInternalAdvanced  
+| 
+|  
+
+| credentialPolicy 
+|  
+| DirectoryInternalCredentialPolicy  
+| 
+|  
+
+| schema 
+|  
+| DirectoryLdapSchema  
+| 
+|  
+
+|===
 
 
 [#ApplicationLinkBean]
@@ -2098,42 +2265,67 @@ endif::internal-generation[]
 
 | directories 
 |  
-| List  of <<DirectoryBean>> 
+| List  of <<AbstractDirectoryBean>> 
 | 
 |  
 
 |===
 
 
-[#DirectoryBean]
-=== _DirectoryBean_ 
+[#DirectoryCrowdAdvanced]
+=== _DirectoryCrowdAdvanced_ 
 
 
 
-[.fields-DirectoryBean]
+[.fields-DirectoryCrowdAdvanced]
 [cols="2,1,2,4,1"]
 |===         
 | Field Name| Required| Type| Description| Format
 
-| active 
+| enableNestedGroups 
 |  
 | Boolean  
 | 
 |  
 
+| enableIncrementalSync 
+|  
+| Boolean  
+| 
+|  
+
+| updateGroupMembershipMethod 
+|  
+| String  
+| 
+|  
+
+| updateSyncIntervalInMinutes 
+|  
+| Integer  
+| 
+| int32 
+
+|===
+
+
+[#DirectoryCrowdBean]
+=== _DirectoryCrowdBean_ 
+
+
+
+[.fields-DirectoryCrowdBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| id 
+|  
+| Long  
+| 
+| int64 
+
 | name 
-| X 
-| String  
-| 
-|  
-
-| clientName 
-| X 
-| String  
-| 
-|  
-
-| type 
 | X 
 | String  
 | 
@@ -2145,7 +2337,81 @@ endif::internal-generation[]
 | 
 |  
 
-| crowdUrl 
+| active 
+|  
+| Boolean  
+| 
+|  
+
+| server 
+|  
+| DirectoryCrowdServer  
+| 
+|  
+
+| permissions 
+|  
+| DirectoryCrowdPermissions  
+| 
+|  
+
+| advanced 
+|  
+| DirectoryCrowdAdvanced  
+| 
+|  
+
+|===
+
+
+[#DirectoryCrowdPermissions]
+=== _DirectoryCrowdPermissions_ 
+
+
+
+[.fields-DirectoryCrowdPermissions]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| readonly 
+|  
+| Boolean  
+| 
+|  
+
+| fullAccess 
+|  
+| Boolean  
+| 
+|  
+
+|===
+
+
+[#DirectoryCrowdServer]
+=== _DirectoryCrowdServer_ 
+
+
+
+[.fields-DirectoryCrowdServer]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| uri 
+| X 
+| URI  
+| 
+| uri 
+
+| proxy 
+|  
+| DirectoryCrowdServerProxy  
+| 
+|  
+
+| appUsername 
 | X 
 | String  
 | 
@@ -2157,31 +2423,431 @@ endif::internal-generation[]
 | 
 |  
 
-| implClass 
+| connectionTimeoutInMillis 
+|  
+| Long  
+| 
+| int64 
+
+| maxConnections 
+|  
+| Integer  
+| 
+| int32 
+
+|===
+
+
+[#DirectoryCrowdServerProxy]
+=== _DirectoryCrowdServerProxy_ 
+
+
+
+[.fields-DirectoryCrowdServerProxy]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| username 
+|  
+| String  
+| 
+|  
+
+| password 
+|  
+| String  
+| 
+|  
+
+| uri 
+|  
+| URI  
+| 
+| uri 
+
+|===
+
+
+[#DirectoryGenericBean]
+=== _DirectoryGenericBean_ 
+
+
+
+[.fields-DirectoryGenericBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| id 
+|  
+| Long  
+| 
+| int64 
+
+| name 
 | X 
 | String  
 | 
 |  
 
-| proxyHost 
+| description 
 |  
 | String  
 | 
 |  
 
-| proxyPort 
+| active 
+|  
+| Boolean  
+| 
+|  
+
+|===
+
+
+[#DirectoryInternalAdvanced]
+=== _DirectoryInternalAdvanced_ 
+
+
+
+[.fields-DirectoryInternalAdvanced]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| enableNestedGroups 
+|  
+| Boolean  
+| 
+|  
+
+|===
+
+
+[#DirectoryInternalBean]
+=== _DirectoryInternalBean_ 
+
+
+
+[.fields-DirectoryInternalBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| id 
+|  
+| Long  
+| 
+| int64 
+
+| name 
+| X 
+| String  
+| 
+|  
+
+| description 
 |  
 | String  
 | 
 |  
 
-| proxyUsername 
+| active 
+|  
+| Boolean  
+| 
+|  
+
+| credentialPolicy 
+|  
+| DirectoryInternalCredentialPolicy  
+| 
+|  
+
+| advanced 
+|  
+| DirectoryInternalAdvanced  
+| 
+|  
+
+| permissions 
+|  
+| DirectoryInternalPermissions  
+| 
+|  
+
+|===
+
+
+[#DirectoryInternalCredentialPolicy]
+=== _DirectoryInternalCredentialPolicy_ 
+
+
+
+[.fields-DirectoryInternalCredentialPolicy]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| passwordRegex 
 |  
 | String  
 | 
 |  
 
-| proxyPassword 
+| passwordComplexityMessage 
+|  
+| String  
+| 
+|  
+
+| passwordMaxAttempts 
+|  
+| Long  
+| 
+| int64 
+
+| passwordHistoryCount 
+|  
+| Long  
+| 
+| int64 
+
+| passwordMaxChangeTime 
+|  
+| Long  
+| 
+| int64 
+
+| passwordExpiryNotificationDays 
+|  
+| List  of <<integer>> 
+| 
+| int32 
+
+| passwordEncryptionMethod 
+|  
+| String  
+| 
+|  
+
+|===
+
+
+[#DirectoryInternalPermissions]
+=== _DirectoryInternalPermissions_ 
+
+
+
+[.fields-DirectoryInternalPermissions]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| addGroup 
+|  
+| Boolean  
+| 
+|  
+
+| addUser 
+|  
+| Boolean  
+| 
+|  
+
+| modifyGroup 
+|  
+| Boolean  
+| 
+|  
+
+| modifyUser 
+|  
+| Boolean  
+| 
+|  
+
+| modifyGroupAttributes 
+|  
+| Boolean  
+| 
+|  
+
+| modifyUserAttributes 
+|  
+| Boolean  
+| 
+|  
+
+| removeGroup 
+|  
+| Boolean  
+| 
+|  
+
+| removeUser 
+|  
+| Boolean  
+| 
+|  
+
+|===
+
+
+[#DirectoryLdapBean]
+=== _DirectoryLdapBean_ 
+
+
+
+[.fields-DirectoryLdapBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| id 
+|  
+| Long  
+| 
+| int64 
+
+| name 
+| X 
+| String  
+| 
+|  
+
+| description 
+|  
+| String  
+| 
+|  
+
+| active 
+|  
+| Boolean  
+| 
+|  
+
+| server 
+|  
+| DirectoryLdapServer  
+| 
+|  
+
+| schema 
+|  
+| DirectoryLdapSchema  
+| 
+|  
+
+| permissions 
+|  
+| DirectoryLdapPermissions  
+| 
+|  
+
+|===
+
+
+[#DirectoryLdapPermissions]
+=== _DirectoryLdapPermissions_ 
+
+
+
+[.fields-DirectoryLdapPermissions]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| readonly 
+|  
+| Boolean  
+| 
+|  
+
+| readonlyForLocalGroups 
+|  
+| Boolean  
+| 
+|  
+
+| fullAccess 
+|  
+| Boolean  
+| 
+|  
+
+|===
+
+
+[#DirectoryLdapSchema]
+=== _DirectoryLdapSchema_ 
+
+
+
+[.fields-DirectoryLdapSchema]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| baseDn 
+|  
+| String  
+| 
+|  
+
+| userDn 
+|  
+| String  
+| 
+|  
+
+| groupDn 
+|  
+| String  
+| 
+|  
+
+|===
+
+
+[#DirectoryLdapServer]
+=== _DirectoryLdapServer_ 
+
+
+
+[.fields-DirectoryLdapServer]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| hostName 
+| X 
+| String  
+| 
+|  
+
+| port 
+|  
+| Integer  
+| 
+| int32 
+
+| useSsl 
+|  
+| Boolean  
+| 
+|  
+
+| username 
+|  
+| String  
+| 
+|  
+
+| password 
 |  
 | String  
 | 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <atlassian.gadgets.version>4.3.2.1</atlassian.gadgets.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.0.14-SNAPSHOT</confapi-commons.version>
+        <confapi-commons.version>0.0.16-SNAPSHOT</confapi-commons.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <log4j.version>2.8.2</log4j.version>
         <openapi-generator-maven-plugin.version>4.3.0</openapi-generator-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>de.aservo.atlassian</groupId>
     <artifactId>confluence-confapi-plugin</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>ConfAPI for Confluence</name>
@@ -62,7 +62,7 @@
         <atlassian.gadgets.version>4.3.2.1</atlassian.gadgets.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.0.10-SNAPSHOT</confapi-commons.version>
+        <confapi-commons.version>0.0.14-SNAPSHOT</confapi-commons.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <log4j.version>2.8.2</log4j.version>
         <openapi-generator-maven-plugin.version>4.3.0</openapi-generator-maven-plugin.version>
@@ -237,18 +237,6 @@
         <dependency>
             <groupId>org.apache.wink</groupId>
             <artifactId>wink-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator-annotation-processor</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
@@ -15,7 +15,6 @@ import de.aservo.confapi.commons.model.DirectoryLdapBean;
 
 import javax.validation.constraints.NotNull;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -71,7 +70,7 @@ public class DirectoryBeanUtil {
      */
     @NotNull
     public static AbstractDirectoryBean toDirectoryBean(
-            @NotNull final Directory directory) throws URISyntaxException {
+            @NotNull final Directory directory) {
 
         final Map<String, String> attributes = directory.getAttributes();
         final AbstractDirectoryBean directoryBean;
@@ -79,7 +78,7 @@ public class DirectoryBeanUtil {
         if (DirectoryType.CROWD.equals(directory.getType())) {
 
             DirectoryCrowdServer serverBean = new DirectoryCrowdServer();
-            serverBean.setUri(new URI(attributes.get(CROWD_SERVER_URL)));
+            serverBean.setUri(URI.create(attributes.get(CROWD_SERVER_URL)));
             if (attributes.containsKey(CROWD_HTTP_PROXY_HOST)) {
                 DirectoryCrowdServerProxy proxy = new DirectoryCrowdServerProxy();
                 proxy.setUsername(attributes.get(CROWD_HTTP_PROXY_USERNAME));

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
@@ -1,18 +1,28 @@
 package de.aservo.atlassian.confluence.confapi.model.util;
 
+import com.atlassian.crowd.directory.RemoteCrowdDirectory;
 import com.atlassian.crowd.embedded.api.Directory;
 import com.atlassian.crowd.embedded.api.DirectoryType;
 import com.atlassian.crowd.model.directory.ImmutableDirectory;
-import de.aservo.confapi.commons.model.DirectoryBean;
+import de.aservo.confapi.commons.model.AbstractDirectoryBean;
+import de.aservo.confapi.commons.model.DirectoryCrowdBean;
+import de.aservo.confapi.commons.model.DirectoryCrowdBean.DirectoryCrowdAdvanced;
+import de.aservo.confapi.commons.model.DirectoryCrowdBean.DirectoryCrowdServer;
+import de.aservo.confapi.commons.model.DirectoryCrowdBean.DirectoryCrowdServer.DirectoryCrowdServerProxy;
+import de.aservo.confapi.commons.model.DirectoryGenericBean;
+import de.aservo.confapi.commons.model.DirectoryInternalBean;
+import de.aservo.confapi.commons.model.DirectoryLdapBean;
 
 import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.atlassian.crowd.directory.RemoteCrowdDirectory.*;
 import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.*;
-import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.SyncGroupMembershipsAfterAuth.WHEN_AUTHENTICATION_CREATED_THE_USER;
 import static com.atlassian.crowd.model.directory.DirectoryImpl.ATTRIBUTE_KEY_USE_NESTED_GROUPS;
+import static de.aservo.confapi.commons.util.ConversionUtil.*;
 
 public class DirectoryBeanUtil {
 
@@ -23,22 +33,29 @@ public class DirectoryBeanUtil {
      */
     @NotNull
     public static Directory toDirectory(
-            @NotNull final DirectoryBean directoryBean) {
+            @NotNull final DirectoryCrowdBean directoryBean) {
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put(CROWD_SERVER_URL, directoryBean.getCrowdUrl());
-        attributes.put(APPLICATION_PASSWORD, directoryBean.getAppPassword());
-        attributes.put(APPLICATION_NAME, directoryBean.getClientName());
-        attributes.put(CROWD_HTTP_PROXY_HOST, directoryBean.getProxyHost());
-        attributes.put(CROWD_HTTP_PROXY_PORT, directoryBean.getProxyPort());
-        attributes.put(CROWD_HTTP_PROXY_USERNAME, directoryBean.getProxyUsername());
-        attributes.put(CROWD_HTTP_PROXY_PASSWORD, directoryBean.getProxyPassword());
-        attributes.put(CACHE_SYNCHRONISE_INTERVAL, "3600");
-        attributes.put(ATTRIBUTE_KEY_USE_NESTED_GROUPS, "false");
-        attributes.put(INCREMENTAL_SYNC_ENABLED, "true");
-        attributes.put(SYNC_GROUP_MEMBERSHIP_AFTER_SUCCESSFUL_USER_AUTH_ENABLED, WHEN_AUTHENTICATION_CREATED_THE_USER.getValue());
+        if (directoryBean.getServer() != null) {
+            attributes.put(CROWD_SERVER_URL, directoryBean.getServer().getUri().toString());
+            attributes.put(APPLICATION_NAME, directoryBean.getServer().getAppUsername());
+            attributes.put(APPLICATION_PASSWORD, directoryBean.getServer().getAppPassword());
+            if (directoryBean.getServer().getProxy() != null) {
+                attributes.put(CROWD_HTTP_PROXY_HOST, directoryBean.getServer().getProxy().getUri().getHost());
+                attributes.put(CROWD_HTTP_PROXY_PORT, String.valueOf(directoryBean.getServer().getProxy().getUri().getPort()));
+                attributes.put(CROWD_HTTP_PROXY_USERNAME, directoryBean.getServer().getProxy().getUsername());
+                attributes.put(CROWD_HTTP_PROXY_PASSWORD, directoryBean.getServer().getProxy().getPassword());
+            }
+        }
+        if (directoryBean.getAdvanced() != null) {
+            attributes.put(CACHE_SYNCHRONISE_INTERVAL, directoryBean.getAdvanced().getUpdateSyncIntervalInMinutes() != 0 ?
+                    String.valueOf(directoryBean.getAdvanced().getUpdateSyncIntervalInMinutes()) : "3600");
+            attributes.put(ATTRIBUTE_KEY_USE_NESTED_GROUPS, String.valueOf(directoryBean.getAdvanced().getEnableNestedGroups()));
+            attributes.put(INCREMENTAL_SYNC_ENABLED, String.valueOf(directoryBean.getAdvanced().getEnableIncrementalSync()));
+            attributes.put(SYNC_GROUP_MEMBERSHIP_AFTER_SUCCESSFUL_USER_AUTH_ENABLED, directoryBean.getAdvanced().getUpdateGroupMembershipMethod());
+        }
 
-        return ImmutableDirectory.builder(directoryBean.getName(), DirectoryBeanUtil.getDirectoryType(directoryBean), directoryBean.getImplClass())
+        return ImmutableDirectory.builder(directoryBean.getName(), DirectoryBeanUtil.getDirectoryType(directoryBean), RemoteCrowdDirectory.class.getName())
                 .setActive(directoryBean.isActive())
                 .setAttributes(attributes)
                 .build();
@@ -51,28 +68,59 @@ public class DirectoryBeanUtil {
      * @return the user directory bean
      */
     @NotNull
-    public static DirectoryBean toDirectoryBean(
-            @NotNull final Directory directory) {
+    public static AbstractDirectoryBean toDirectoryBean(
+            @NotNull final Directory directory) throws URISyntaxException {
 
         final Map<String, String> attributes = directory.getAttributes();
-        final DirectoryBean directoryBean = new DirectoryBean();
+        final AbstractDirectoryBean directoryBean;
+
+        if (DirectoryType.CROWD.equals(directory.getType())) {
+
+            DirectoryCrowdServer serverBean = new DirectoryCrowdServer();
+            serverBean.setUri(new URI(attributes.get(CROWD_SERVER_URL)));
+            if (attributes.containsKey(CROWD_HTTP_PROXY_HOST)) {
+                DirectoryCrowdServerProxy proxy = new DirectoryCrowdServerProxy();
+                proxy.setUsername(attributes.get(CROWD_HTTP_PROXY_USERNAME));
+                String proxyUrl = attributes.get(CROWD_HTTP_PROXY_HOST) +
+                        (attributes.get(CROWD_HTTP_PROXY_PORT) == null ? "" : ":" + attributes.get(CROWD_HTTP_PROXY_PORT));
+                proxy.setUri(new URI(proxyUrl));
+                serverBean.setProxy(proxy);
+            }
+            serverBean.setConnectionTimeoutInMillis(toLong(attributes.get(CROWD_HTTP_TIMEOUT)));
+            serverBean.setMaxConnections(toInt(attributes.get(CROWD_HTTP_MAX_CONNECTIONS)));
+            serverBean.setAppUsername(attributes.get(APPLICATION_NAME));
+
+            DirectoryCrowdAdvanced advanced = new DirectoryCrowdAdvanced();
+            advanced.setEnableIncrementalSync(toBoolean(attributes.get(INCREMENTAL_SYNC_ENABLED)));
+            advanced.setEnableNestedGroups(toBoolean(attributes.get(ATTRIBUTE_KEY_USE_NESTED_GROUPS)));
+            advanced.setUpdateSyncIntervalInMinutes(toInt(attributes.get(CACHE_SYNCHRONISE_INTERVAL)));
+
+            DirectoryCrowdBean directoryCrowdBean = new DirectoryCrowdBean();
+            directoryCrowdBean.setServer(serverBean);
+            directoryCrowdBean.setAdvanced(advanced);
+            directoryBean = directoryCrowdBean;
+
+        } else  {
+            directoryBean = new DirectoryGenericBean();
+        }
+
         directoryBean.setName(directory.getName());
         directoryBean.setActive(directory.isActive());
-        directoryBean.setType(directory.getType().name());
         directoryBean.setDescription(directory.getDescription());
-        directoryBean.setCrowdUrl(attributes.get(CROWD_SERVER_URL));
-        directoryBean.setClientName(attributes.get(APPLICATION_NAME));
-        directoryBean.setProxyHost(attributes.get(CROWD_HTTP_PROXY_HOST));
-        directoryBean.setProxyPort(attributes.get(CROWD_HTTP_PROXY_PORT));
-        directoryBean.setProxyUsername(attributes.get(CROWD_HTTP_PROXY_USERNAME));
-        directoryBean.setImplClass(directory.getImplementationClass());
         return directoryBean;
     }
 
     public static DirectoryType getDirectoryType(
-            @NotNull final DirectoryBean directoryBean) {
-
-        return DirectoryType.valueOf(directoryBean.getType().toUpperCase());
+            @NotNull final AbstractDirectoryBean directoryBean) {
+        if (directoryBean instanceof DirectoryInternalBean) {
+            return DirectoryType.INTERNAL;
+        } else if (directoryBean instanceof DirectoryCrowdBean) {
+            return DirectoryType.CROWD;
+        } else if (directoryBean instanceof DirectoryLdapBean) {
+            return DirectoryType.DELEGATING;
+        } else {
+            return DirectoryType.UNKNOWN;
+        }
     }
 
     private DirectoryBeanUtil() {

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtil.java
@@ -41,8 +41,10 @@ public class DirectoryBeanUtil {
             attributes.put(APPLICATION_NAME, directoryBean.getServer().getAppUsername());
             attributes.put(APPLICATION_PASSWORD, directoryBean.getServer().getAppPassword());
             if (directoryBean.getServer().getProxy() != null) {
-                attributes.put(CROWD_HTTP_PROXY_HOST, directoryBean.getServer().getProxy().getUri().getHost());
-                attributes.put(CROWD_HTTP_PROXY_PORT, String.valueOf(directoryBean.getServer().getProxy().getUri().getPort()));
+                attributes.put(CROWD_HTTP_PROXY_HOST, directoryBean.getServer().getProxy().getHost());
+                if (directoryBean.getServer().getProxy().getPort() != null) {
+                    attributes.put(CROWD_HTTP_PROXY_PORT, directoryBean.getServer().getProxy().getPort().toString());
+                }
                 attributes.put(CROWD_HTTP_PROXY_USERNAME, directoryBean.getServer().getProxy().getUsername());
                 attributes.put(CROWD_HTTP_PROXY_PASSWORD, directoryBean.getServer().getProxy().getPassword());
             }
@@ -81,9 +83,10 @@ public class DirectoryBeanUtil {
             if (attributes.containsKey(CROWD_HTTP_PROXY_HOST)) {
                 DirectoryCrowdServerProxy proxy = new DirectoryCrowdServerProxy();
                 proxy.setUsername(attributes.get(CROWD_HTTP_PROXY_USERNAME));
-                String proxyUrl = attributes.get(CROWD_HTTP_PROXY_HOST) +
-                        (attributes.get(CROWD_HTTP_PROXY_PORT) == null ? "" : ":" + attributes.get(CROWD_HTTP_PROXY_PORT));
-                proxy.setUri(new URI(proxyUrl));
+                proxy.setHost(attributes.get(CROWD_HTTP_PROXY_HOST));
+                if (attributes.get(CROWD_HTTP_PROXY_PORT) != null) {
+                    proxy.setPort(Integer.valueOf(attributes.get(CROWD_HTTP_PROXY_PORT)));
+                }
                 serverBean.setProxy(proxy);
             }
             serverBean.setConnectionTimeoutInMillis(toLong(attributes.get(CROWD_HTTP_TIMEOUT)));

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceImpl.java
@@ -61,13 +61,19 @@ public class ApplicationLinkServiceImpl implements ApplicationLinksService {
     }
 
     @Override
-    public ApplicationLinksBean setApplicationLinks(ApplicationLinksBean applicationLinksBean) {
-        applicationLinksBean.getApplicationLinks().forEach(this::addApplicationLink);
+    public ApplicationLinksBean setApplicationLinks(
+            final ApplicationLinksBean applicationLinksBean,
+            final boolean ignoreSetupErrors) {
+
+        applicationLinksBean.getApplicationLinks().forEach(link -> addApplicationLink(link, ignoreSetupErrors));
         return getApplicationLinks();
     }
 
     @Override
-    public ApplicationLinkBean addApplicationLink(ApplicationLinkBean linkBean) {
+    public ApplicationLinkBean addApplicationLink(
+            final ApplicationLinkBean linkBean,
+            final boolean ignoreSetupErrors) {
+
         //preparations
         validate(linkBean);
 

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceImpl.java
@@ -67,7 +67,7 @@ public class ApplicationLinkServiceImpl implements ApplicationLinksService {
     }
 
     @Override
-    public ApplicationLinksBean addApplicationLink(ApplicationLinkBean linkBean) {
+    public ApplicationLinkBean addApplicationLink(ApplicationLinkBean linkBean) {
         //preparations
         validate(linkBean);
 
@@ -95,11 +95,10 @@ public class ApplicationLinkServiceImpl implements ApplicationLinksService {
             applicationLink = mutatingApplicationLinkService.createApplicationLink(applicationType, linkDetails);
             mutatingApplicationLinkService.configureAuthenticationForApplicationLink(applicationLink,
                     new DefaultAuthenticationScenario(), linkBean.getUsername(), linkBean.getPassword());
+            return ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
         } catch (ManifestNotFoundException | AuthenticationConfigurationException e) {
             throw new BadRequestException(e.getMessage());
         }
-
-        return getApplicationLinks();
     }
 
     private ApplicationType buildApplicationType(ApplicationLinkTypes linkType) {

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceImpl.java
@@ -7,19 +7,23 @@ import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import de.aservo.atlassian.confluence.confapi.model.util.DirectoryBeanUtil;
 import de.aservo.confapi.commons.exception.InternalServerErrorException;
-import de.aservo.confapi.commons.model.DirectoryBean;
+import de.aservo.confapi.commons.model.AbstractDirectoryBean;
+import de.aservo.confapi.commons.model.DirectoriesBean;
+import de.aservo.confapi.commons.model.DirectoryCrowdBean;
 import de.aservo.confapi.commons.service.api.DirectoryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static de.aservo.confapi.commons.util.BeanValidationUtil.validate;
+import static java.lang.String.format;
 
 @Component
 @ExportAsService(DirectoryService.class)
@@ -34,35 +38,77 @@ public class DirectoryServiceImpl implements DirectoryService {
         this.crowdDirectoryService = checkNotNull(crowdDirectoryService);
     }
 
-    public List<DirectoryBean> getDirectories() {
-        return crowdDirectoryService.findAllDirectories().stream().map(DirectoryBeanUtil::toDirectoryBean).collect(Collectors.toList());
+    @Override
+    public DirectoriesBean getDirectories() {
+        List<AbstractDirectoryBean> beans = new ArrayList<>();
+        for (Directory directory : crowdDirectoryService.findAllDirectories()) {
+            AbstractDirectoryBean crowdBean;
+            try {
+                crowdBean = DirectoryBeanUtil.toDirectoryBean(directory);
+                beans.add(crowdBean);
+            } catch (URISyntaxException e) {
+                throw new InternalServerErrorException(e);
+            }
+        }
+        return new DirectoriesBean(beans);
     }
 
-    public DirectoryBean setDirectory(DirectoryBean directoryBean, boolean testConnection) {
+    @Override
+    public DirectoriesBean setDirectories(DirectoriesBean directoriesBean, boolean testConnection) {
+        directoriesBean.getDirectories().forEach(directoryBaseBean -> {
+            if (directoryBaseBean instanceof DirectoryCrowdBean) {
 
-        //preps and validation
-        validate(directoryBean);
-        Directory directory = DirectoryBeanUtil.toDirectory(directoryBean);
-        String directoryName = directoryBean.getName();
+                //preps and validation
+                DirectoryCrowdBean crowdBean = (DirectoryCrowdBean)directoryBaseBean;
+                Directory directory = validateAndCreateDirectoryConfig(crowdBean, testConnection);
+
+                //check if directory exists already and if yes, remove it
+                Optional<Directory> presentDirectory = crowdDirectoryService.findAllDirectories().stream()
+                        .filter(dir -> dir.getName().equals(directory.getName())).findFirst();
+                if (presentDirectory.isPresent()) {
+                    Directory presentDir = presentDirectory.get();
+                    log.info("removing existing user directory configuration '{}' before adding new configuration '{}'", presentDir.getName(), directory.getName());
+                    try {
+                        crowdDirectoryService.removeDirectory(presentDir.getId());
+                    } catch (DirectoryCurrentlySynchronisingException e) {
+                        throw new InternalServerErrorException(e.getMessage());
+                    }
+                }
+
+                //add new directory
+                crowdDirectoryService.addDirectory(directory);
+            } else {
+                throw new InternalServerErrorException(format("Setting directory type '%s' is not supported (yet)", directoryBaseBean.getClass()));
+            }
+        });
+        return getDirectories();
+    }
+
+    @Override
+    public AbstractDirectoryBean addDirectory(AbstractDirectoryBean abstractDirectoryBean, boolean testConnection) {
+        if (abstractDirectoryBean instanceof DirectoryCrowdBean) {
+            DirectoryCrowdBean crowdBean = (DirectoryCrowdBean)abstractDirectoryBean;
+            Directory directory = validateAndCreateDirectoryConfig(crowdBean, testConnection);
+            Directory addedDirectory = crowdDirectoryService.addDirectory(directory);
+            try {
+                return DirectoryBeanUtil.toDirectoryBean(addedDirectory);
+            } catch (URISyntaxException e) {
+                throw new InternalServerErrorException(e);
+            }
+        } else {
+            throw new InternalServerErrorException(format("Adding directory type '%s' is not supported (yet)", abstractDirectoryBean.getClass()));
+        }
+    }
+
+    private Directory validateAndCreateDirectoryConfig(DirectoryCrowdBean crowdBean, boolean testConnection) {
+        validate(crowdBean);
+        Directory directory = DirectoryBeanUtil.toDirectory(crowdBean);
+        String directoryName = crowdBean.getName();
         if (testConnection) {
             log.debug("testing user directory connection for {}", directoryName);
             crowdDirectoryService.testConnection(directory);
         }
-
-        //check if directory exists already and if yes, remove it
-        Optional<Directory> presentDirectory = crowdDirectoryService.findAllDirectories().stream().filter(dir -> dir.getName().equals(directory.getName())).findFirst();
-        if (presentDirectory.isPresent()) {
-            Directory presentDir = presentDirectory.get();
-            log.info("removing existing user directory configuration '{}' before adding new configuration '{}'", presentDir.getName(), directory.getName());
-            try {
-                crowdDirectoryService.removeDirectory(presentDir.getId());
-            } catch (DirectoryCurrentlySynchronisingException e) {
-                throw new InternalServerErrorException(e.getMessage());
-            }
-        }
-
-        //add new directory
-        return DirectoryBeanUtil.toDirectoryBean(crowdDirectoryService.addDirectory(directory));
+        return directory;
     }
 
 }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceImpl.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -43,12 +42,8 @@ public class DirectoryServiceImpl implements DirectoryService {
         List<AbstractDirectoryBean> beans = new ArrayList<>();
         for (Directory directory : crowdDirectoryService.findAllDirectories()) {
             AbstractDirectoryBean crowdBean;
-            try {
-                crowdBean = DirectoryBeanUtil.toDirectoryBean(directory);
-                beans.add(crowdBean);
-            } catch (URISyntaxException e) {
-                throw new InternalServerErrorException(e);
-            }
+            crowdBean = DirectoryBeanUtil.toDirectoryBean(directory);
+            beans.add(crowdBean);
         }
         return new DirectoriesBean(beans);
     }
@@ -90,11 +85,7 @@ public class DirectoryServiceImpl implements DirectoryService {
             DirectoryCrowdBean crowdBean = (DirectoryCrowdBean)abstractDirectoryBean;
             Directory directory = validateAndCreateDirectoryConfig(crowdBean, testConnection);
             Directory addedDirectory = crowdDirectoryService.addDirectory(directory);
-            try {
-                return DirectoryBeanUtil.toDirectoryBean(addedDirectory);
-            } catch (URISyntaxException e) {
-                throw new InternalServerErrorException(e);
-            }
+            return DirectoryBeanUtil.toDirectoryBean(addedDirectory);
         } else {
             throw new InternalServerErrorException(format("Adding directory type '%s' is not supported (yet)", abstractDirectoryBean.getClass()));
         }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/GadgetsServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/GadgetsServiceImpl.java
@@ -69,7 +69,7 @@ public class GadgetsServiceImpl implements GadgetsService {
     }
 
     @Override
-    public GadgetsBean addGadget(GadgetBean gadgetBean) {
+    public GadgetBean addGadget(GadgetBean gadgetBean) {
         //initial checks
         String url = gadgetBean.getUrl();
         if (StringUtils.isBlank(url)) {
@@ -94,8 +94,10 @@ public class GadgetsServiceImpl implements GadgetsService {
         gadgetSpecFactory.getGadgetSpec(uri, requestContext);
 
         //add gadget url to store
-        externalGadgetSpecStore.add(uri);
+        ExternalGadgetSpec addedGadget = externalGadgetSpecStore.add(uri);
 
-        return getGadgets();
+        GadgetBean addedGadgetBean = new GadgetBean();
+        addedGadgetBean.setUrl(addedGadget.getSpecUri().toString());
+        return addedGadgetBean;
     }
 }

--- a/src/main/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceImpl.java
@@ -50,22 +50,22 @@ public class LicensesServiceImpl implements LicensesService {
             }));
 
             //set licenses
-            licensesBean.getLicenses().forEach(this::setLicense);
+            licensesBean.getLicenses().forEach(this::addLicense);
         } else {
             //set first license from bean for non multi-license hosts
-            setLicense(licensesBean.getLicenses().iterator().next());
+            addLicense(licensesBean.getLicenses().iterator().next());
         }
 
         return getLicenses();
     }
 
     @Override
-    public LicensesBean setLicense(LicenseBean licenseBean) {
+    public LicenseBean addLicense(LicenseBean licenseBean) {
         try {
             licenseHandler.addProductLicense(DEFAULT_LICENSE_REGISTRY_KEY, licenseBean.getKey());
         } catch (InvalidOperationException e) {
             throw new BadRequestException("The new license cannot be set");
         }
-        return getLicenses();
+        return licenseBean;
     }
 }

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
@@ -43,8 +43,9 @@ public class DirectoryBeanUtilTest {
         final Map<String, String> attributes = directory.getAttributes();
         assertEquals(bean.getServer().getUri().toString(), attributes.get(CROWD_SERVER_URL));
         assertEquals(bean.getServer().getAppPassword(), attributes.get(APPLICATION_PASSWORD));
-        assertEquals(bean.getServer().getProxy().getUri().getHost(), attributes.get(CROWD_HTTP_PROXY_HOST));
-        assertEquals(String.valueOf(bean.getServer().getProxy().getUri().getPort()), attributes.get(CROWD_HTTP_PROXY_PORT));
+        assertEquals(bean.getServer().getProxy().getHost(), attributes.get(CROWD_HTTP_PROXY_HOST));
+        assertNull(bean.getServer().getProxy().getPort());
+        assertNull(attributes.get(CROWD_HTTP_PROXY_PORT));
         assertEquals(bean.getServer().getProxy().getUsername(), attributes.get(CROWD_HTTP_PROXY_USERNAME));
         assertEquals(bean.getServer().getProxy().getPassword(), attributes.get(CROWD_HTTP_PROXY_PASSWORD));
     }
@@ -76,7 +77,8 @@ public class DirectoryBeanUtilTest {
         final Map<String, String> attributes = directory.getAttributes();
         assertEquals(attributes.get(CROWD_SERVER_URL), directoryBean.getServer().getUri().toString());
         assertNull(directoryBean.getServer().getAppPassword());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_HOST) + ":" + attributes.get(CROWD_HTTP_PROXY_PORT), directoryBean.getServer().getProxy().getUri().toString());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_HOST), directoryBean.getServer().getProxy().getHost());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_PORT), directoryBean.getServer().getProxy().getPort().toString());
         assertEquals(attributes.get(CROWD_HTTP_PROXY_USERNAME), directoryBean.getServer().getProxy().getUsername());
         assertNull(directoryBean.getServer().getProxy().getPassword());
     }

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/model/util/DirectoryBeanUtilTest.java
@@ -3,40 +3,54 @@ package de.aservo.atlassian.confluence.confapi.model.util;
 import com.atlassian.crowd.embedded.api.Directory;
 import com.atlassian.crowd.embedded.api.DirectoryType;
 import com.atlassian.crowd.model.directory.DirectoryImpl;
-import de.aservo.confapi.commons.model.DirectoryBean;
+import de.aservo.confapi.commons.model.DirectoryCrowdBean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.net.URISyntaxException;
 import java.util.Map;
 
 import static com.atlassian.crowd.directory.RemoteCrowdDirectory.*;
+import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.INCREMENTAL_SYNC_ENABLED;
+import static com.atlassian.crowd.model.directory.DirectoryImpl.ATTRIBUTE_KEY_USE_NESTED_GROUPS;
 import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DirectoryBeanUtilTest {
 
     @Test
-    public void testToDirectory() {
-        final DirectoryBean bean = DirectoryBean.EXAMPLE_1;
+    public void testToDirectoryWithoutProxy() {
+        final DirectoryCrowdBean bean = DirectoryCrowdBean.EXAMPLE_1;
         final Directory directory = DirectoryBeanUtil.toDirectory(bean);
 
         assertNotNull(directory);
         assertEquals(directory.getName(), bean.getName());
-        assertEquals(directory.getType().name(), bean.getType().toUpperCase());
-        assertEquals(directory.getImplementationClass(), bean.getImplClass());
 
         final Map<String, String> attributes = directory.getAttributes();
-        assertEquals(attributes.get(CROWD_SERVER_URL), bean.getCrowdUrl());
-        assertEquals(attributes.get(APPLICATION_PASSWORD), bean.getAppPassword());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_HOST), bean.getProxyHost());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_PORT), bean.getProxyPort());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_USERNAME), bean.getProxyUsername());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_PASSWORD), bean.getProxyPassword());
+        assertEquals(attributes.get(CROWD_SERVER_URL), bean.getServer().getUri().toString());
+        assertEquals(attributes.get(APPLICATION_PASSWORD), bean.getServer().getAppPassword());
     }
 
     @Test
-    public void testToDirectoryBean() {
+    public void testToDirectoryWithProxy() {
+        final DirectoryCrowdBean bean = DirectoryCrowdBean.EXAMPLE_1_WITH_PROXY;
+        final Directory directory = DirectoryBeanUtil.toDirectory(bean);
+
+        assertNotNull(directory);
+        assertEquals(directory.getName(), bean.getName());
+
+        final Map<String, String> attributes = directory.getAttributes();
+        assertEquals(bean.getServer().getUri().toString(), attributes.get(CROWD_SERVER_URL));
+        assertEquals(bean.getServer().getAppPassword(), attributes.get(APPLICATION_PASSWORD));
+        assertEquals(bean.getServer().getProxy().getUri().getHost(), attributes.get(CROWD_HTTP_PROXY_HOST));
+        assertEquals(String.valueOf(bean.getServer().getProxy().getUri().getPort()), attributes.get(CROWD_HTTP_PROXY_PORT));
+        assertEquals(bean.getServer().getProxy().getUsername(), attributes.get(CROWD_HTTP_PROXY_USERNAME));
+        assertEquals(bean.getServer().getProxy().getPassword(), attributes.get(CROWD_HTTP_PROXY_PASSWORD));
+    }
+
+    @Test
+    public void testToDirectoryBeanWithProxy() throws URISyntaxException {
         final DirectoryImpl directory = new DirectoryImpl("test", DirectoryType.CROWD, "test.class");
         directory.setAttribute(CROWD_SERVER_URL, "http://localhost");
         directory.setAttribute(APPLICATION_PASSWORD, "test");
@@ -45,22 +59,26 @@ public class DirectoryBeanUtilTest {
         directory.setAttribute(CROWD_HTTP_PROXY_PORT, "8080");
         directory.setAttribute(CROWD_HTTP_PROXY_USERNAME, "user");
         directory.setAttribute(CROWD_HTTP_PROXY_PASSWORD, "pass");
+        directory.setAttribute(CROWD_HTTP_TIMEOUT, "");
+        directory.setAttribute(CROWD_HTTP_MAX_CONNECTIONS, "");
+        directory.setAttribute(APPLICATION_NAME, "");
+        directory.setAttribute(APPLICATION_PASSWORD, "");
+        directory.setAttribute(INCREMENTAL_SYNC_ENABLED, "");
+        directory.setAttribute(ATTRIBUTE_KEY_USE_NESTED_GROUPS, "");
+        directory.setAttribute(INCREMENTAL_SYNC_ENABLED, "");
+        directory.setAttribute(INCREMENTAL_SYNC_ENABLED, "");
 
-        final DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
+        final DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
 
         assertNotNull(directoryBean);
         assertEquals(directory.getName(), directoryBean.getName());
-        assertEquals(directory.getType().name(), directoryBean.getType());
-        assertEquals(directory.getImplementationClass(), directoryBean.getImplClass());
 
         final Map<String, String> attributes = directory.getAttributes();
-        assertEquals(attributes.get(CROWD_SERVER_URL), directoryBean.getCrowdUrl());
-        assertEquals(attributes.get(APPLICATION_NAME), directoryBean.getClientName());
-        assertNull(directoryBean.getAppPassword());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_HOST), directoryBean.getProxyHost());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_PORT), directoryBean.getProxyPort());
-        assertEquals(attributes.get(CROWD_HTTP_PROXY_USERNAME), directoryBean.getProxyUsername());
-        assertNull(directoryBean.getProxyPassword());
+        assertEquals(attributes.get(CROWD_SERVER_URL), directoryBean.getServer().getUri().toString());
+        assertNull(directoryBean.getServer().getAppPassword());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_HOST) + ":" + attributes.get(CROWD_HTTP_PROXY_PORT), directoryBean.getServer().getProxy().getUri().toString());
+        assertEquals(attributes.get(CROWD_HTTP_PROXY_USERNAME), directoryBean.getServer().getProxy().getUsername());
+        assertNull(directoryBean.getServer().getProxy().getPassword());
     }
 
 }

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
@@ -89,14 +89,13 @@ public class ApplicationLinkServiceTest {
         ApplicationLink applicationLink = createApplicationLink();
         ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
 
-        doReturn(Collections.singletonList(applicationLink)).when(mutatingApplicationLinkService).getApplicationLinks();
         doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
                 any(ApplicationType.class), any(ApplicationLinkDetails.class));
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
 
-        ApplicationLinksBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
 
-        assertEquals(applicationLinkResponse.getApplicationLinks().iterator().next().getName(), applicationLinkBean.getName());
+        assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
         assertNotEquals(applicationLinkResponse, applicationLinkBean);
     }
 
@@ -105,15 +104,14 @@ public class ApplicationLinkServiceTest {
         ApplicationLink applicationLink = createApplicationLink();
         ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
 
-        doReturn(Collections.singletonList(applicationLink)).when(mutatingApplicationLinkService).getApplicationLinks();
         doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
                 any(ApplicationType.class), any(ApplicationLinkDetails.class));
         doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
 
-        ApplicationLinksBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
 
-        assertEquals(applicationLinkResponse.getApplicationLinks().iterator().next().getName(), applicationLinkBean.getName());
+        assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
         assertNotEquals(applicationLinkResponse, applicationLinkBean);
     }
 
@@ -132,15 +130,13 @@ public class ApplicationLinkServiceTest {
             ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
             applicationLinkBean.setLinkType(linkType);
 
-            doReturn(Collections.singletonList(applicationLink)).when(mutatingApplicationLinkService).getApplicationLinks();
             doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
                     any(ApplicationType.class), any(ApplicationLinkDetails.class));
             doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
 
-            ApplicationLinksBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+            ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
 
-            assertEquals(applicationLinkResponse.getApplicationLinks().iterator().next().getName(), applicationLinkBean.getName());
-            // TODO: assertEquals(applicationLinkResponse.getLinkType(), applicationLink.getType());
+            assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
         }
     }
 

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/ApplicationLinkServiceTest.java
@@ -76,7 +76,7 @@ public class ApplicationLinkServiceTest {
                 any(ApplicationType.class), any(ApplicationLinkDetails.class));
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
 
-        ApplicationLinksBean applicationLinkResponse = applicationLinkService.setApplicationLinks(applicationLinksBean);
+        ApplicationLinksBean applicationLinkResponse = applicationLinkService.setApplicationLinks(applicationLinksBean, true);
 
         assertEquals(applicationLinkResponse.getApplicationLinks().iterator().next().getName(), applicationLinkBean.getName());
         assertNotEquals(applicationLinkResponse, applicationLinkBean);
@@ -93,7 +93,7 @@ public class ApplicationLinkServiceTest {
                 any(ApplicationType.class), any(ApplicationLinkDetails.class));
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
 
-        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, true);
 
         assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
         assertNotEquals(applicationLinkResponse, applicationLinkBean);
@@ -109,7 +109,7 @@ public class ApplicationLinkServiceTest {
         doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
 
-        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, true);
 
         assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
         assertNotEquals(applicationLinkResponse, applicationLinkBean);
@@ -120,7 +120,7 @@ public class ApplicationLinkServiceTest {
         ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
         applicationLinkBean.setLinkType(null);
 
-        applicationLinkService.addApplicationLink(applicationLinkBean);
+        applicationLinkService.addApplicationLink(applicationLinkBean, true);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class ApplicationLinkServiceTest {
                     any(ApplicationType.class), any(ApplicationLinkDetails.class));
             doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
 
-            ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean);
+            ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, true);
 
             assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
         }

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
@@ -7,7 +7,9 @@ import com.atlassian.crowd.exception.DirectoryCurrentlySynchronisingException;
 import com.atlassian.crowd.model.directory.ImmutableDirectory;
 import de.aservo.atlassian.confluence.confapi.model.util.DirectoryBeanUtil;
 import de.aservo.confapi.commons.exception.InternalServerErrorException;
-import de.aservo.confapi.commons.model.DirectoryBean;
+import de.aservo.confapi.commons.model.AbstractDirectoryBean;
+import de.aservo.confapi.commons.model.DirectoriesBean;
+import de.aservo.confapi.commons.model.DirectoryCrowdBean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,9 +17,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.validation.ValidationException;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.atlassian.crowd.directory.RemoteCrowdDirectory.*;
@@ -43,76 +45,113 @@ public class DirectoryServiceTest {
     }
 
     @Test
-    public void testGetDirectories() {
+    public void testGetDirectories() throws URISyntaxException {
         Directory directory = createDirectory();
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
 
-        List<DirectoryBean> directories = directoryService.getDirectories();
+        DirectoriesBean directories = directoryService.getDirectories();
 
-        assertEquals(directories.get(0), DirectoryBeanUtil.toDirectoryBean(directory));
-    }
-
-    @Test
-    public void testSetDirectoryWithoutExistingDirectory() {
-        Directory directory = createDirectory();
-        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
-
-        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
-        directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, false);
-
-        assertEquals(directoryAdded.getName(), directoryBean.getName());
-    }
-
-    @Test
-    public void testSetDirectoryWithExistingDirectory() {
-        Directory directory = createDirectory();
-        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
-        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
-
-        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
-        directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, false);
-
-        assertEquals(directoryAdded.getName(), directoryBean.getName());
-    }
-
-    @Test
-    public void testSetDirectoryWithConnectionTest() {
-        Directory directory = createDirectory();
-        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
-
-        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
-        directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, true);
-
-        assertEquals(directoryAdded.getName(), directoryBean.getName());
-    }
-
-    @Test(expected = ValidationException.class)
-    public void testSetDirectoryInvalidBean() {
-        Directory directory = createDirectory();
-        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
-        directoryBean.setAppPassword("test");
-        directoryBean.setClientName(null);
-
-        directoryService.setDirectory(directoryBean, false);
+        assertEquals(directories.getDirectories().iterator().next(), DirectoryBeanUtil.toDirectoryBean(directory));
     }
 
     @Test(expected = InternalServerErrorException.class)
-    public void testSetDirectoryDirectoryCurrentlySynchronisingException() throws DirectoryCurrentlySynchronisingException {
+    public void testGetDirectoriesUriException() {
+        Directory directory = createDirectory("öäöää://uhveuehvde");
+        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
+
+        directoryService.getDirectories();
+    }
+
+    @Test
+    public void testSetDirectoriesWithoutExistingDirectory() throws URISyntaxException {
+        Directory directory = createDirectory();
+        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
+        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
+
+        DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.getServer().setAppPassword("test");
+        DirectoriesBean directoryAdded = directoryService.setDirectories(new DirectoriesBean(Collections.singletonList(directoryBean)), false);
+
+        assertEquals(directoryAdded.getDirectories().iterator().next().getName(), directoryBean.getName());
+    }
+
+    @Test
+    public void testSetDirectoryWithExistingDirectory() throws URISyntaxException {
+        Directory directory = createDirectory();
+        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
+        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
+
+        DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.getServer().setAppPassword("test");
+        DirectoriesBean directoryAdded = directoryService.setDirectories(new DirectoriesBean(Collections.singletonList(directoryBean)), false);
+
+        assertEquals(directoryAdded.getDirectories().iterator().next().getName(), directoryBean.getName());
+    }
+
+    @Test
+    public void testSetDirectoryWithConnectionTest() throws URISyntaxException {
+        Directory directory = createDirectory();
+        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
+        doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
+
+        DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.getServer().setAppPassword("test");
+        DirectoriesBean directoryAdded = directoryService.setDirectories(new DirectoriesBean(Collections.singletonList(directoryBean)), true);
+
+        assertEquals(directoryAdded.getDirectories().iterator().next().getName(), directoryBean.getName());
+    }
+
+    @Test(expected = InternalServerErrorException.class)
+    public void testAddDirectoryUriException() throws URISyntaxException {
+        Directory responseDirectory = createDirectory("öäöää://uhveuehvde");
+        doReturn(responseDirectory).when(crowdDirectoryService).addDirectory(any());
+
+        Directory directory = createDirectory();
+        DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
+
+        directoryService.addDirectory(directoryBean, false);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testAddDirectoryInvalidBean() throws URISyntaxException {
+        Directory directory = createDirectory();
+        DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.setName(null);
+
+        directoryService.addDirectory(directoryBean, false);
+    }
+
+    @Test
+    public void testAddDirectory() throws URISyntaxException {
+        Directory directory = createDirectory();
+        doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
+
+        DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.getServer().setAppPassword("test");
+
+        AbstractDirectoryBean directoryAdded = directoryService.addDirectory(directoryBean, false);
+        assertEquals(directoryAdded.getName(), directoryBean.getName());
+    }
+
+
+    @Test(expected = InternalServerErrorException.class)
+    public void testSetDirectoryDirectoryCurrentlySynchronisingException() throws DirectoryCurrentlySynchronisingException, URISyntaxException {
         Directory directory = createDirectory();
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
         doThrow(new DirectoryCurrentlySynchronisingException(1L)).when(crowdDirectoryService).removeDirectory(1L);
 
-        DirectoryBean directoryBean = DirectoryBeanUtil.toDirectoryBean(directory);
-        directoryBean.setAppPassword("test");
-        DirectoryBean directoryAdded = directoryService.setDirectory(directoryBean, false);
+        DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
+        directoryBean.getServer().setAppPassword("test");
+        directoryService.setDirectories(new DirectoriesBean(Collections.singletonList(directoryBean)), false);
     }
 
     private Directory createDirectory() {
+        return createDirectory("http://localhost");
+    }
+
+    private Directory createDirectory(String url) {
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(CROWD_SERVER_URL, "http://localhost");
+        attributes.put(CROWD_SERVER_URL, url);
         attributes.put(APPLICATION_PASSWORD, "test");
         attributes.put(APPLICATION_NAME, "confluence-client");
         attributes.put(CACHE_SYNCHRONISE_INTERVAL, "3600");

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/DirectoryServiceTest.java
@@ -54,16 +54,15 @@ public class DirectoryServiceTest {
         assertEquals(directories.getDirectories().iterator().next(), DirectoryBeanUtil.toDirectoryBean(directory));
     }
 
-    @Test(expected = InternalServerErrorException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testGetDirectoriesUriException() {
         Directory directory = createDirectory("öäöää://uhveuehvde");
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
-
         directoryService.getDirectories();
     }
 
     @Test
-    public void testSetDirectoriesWithoutExistingDirectory() throws URISyntaxException {
+    public void testSetDirectoriesWithoutExistingDirectory() {
         Directory directory = createDirectory();
         doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
@@ -76,7 +75,7 @@ public class DirectoryServiceTest {
     }
 
     @Test
-    public void testSetDirectoryWithExistingDirectory() throws URISyntaxException {
+    public void testSetDirectoryWithExistingDirectory() {
         Directory directory = createDirectory();
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
         doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
@@ -89,7 +88,7 @@ public class DirectoryServiceTest {
     }
 
     @Test
-    public void testSetDirectoryWithConnectionTest() throws URISyntaxException {
+    public void testSetDirectoryWithConnectionTest() {
         Directory directory = createDirectory();
         doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
@@ -101,8 +100,8 @@ public class DirectoryServiceTest {
         assertEquals(directoryAdded.getDirectories().iterator().next().getName(), directoryBean.getName());
     }
 
-    @Test(expected = InternalServerErrorException.class)
-    public void testAddDirectoryUriException() throws URISyntaxException {
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDirectoryUriException() {
         Directory responseDirectory = createDirectory("öäöää://uhveuehvde");
         doReturn(responseDirectory).when(crowdDirectoryService).addDirectory(any());
 
@@ -113,7 +112,7 @@ public class DirectoryServiceTest {
     }
 
     @Test(expected = ValidationException.class)
-    public void testAddDirectoryInvalidBean() throws URISyntaxException {
+    public void testAddDirectoryInvalidBean() {
         Directory directory = createDirectory();
         DirectoryCrowdBean directoryBean = (DirectoryCrowdBean)DirectoryBeanUtil.toDirectoryBean(directory);
         directoryBean.setName(null);
@@ -122,7 +121,7 @@ public class DirectoryServiceTest {
     }
 
     @Test
-    public void testAddDirectory() throws URISyntaxException {
+    public void testAddDirectory() {
         Directory directory = createDirectory();
         doReturn(directory).when(crowdDirectoryService).addDirectory(any(Directory.class));
 
@@ -135,7 +134,7 @@ public class DirectoryServiceTest {
 
 
     @Test(expected = InternalServerErrorException.class)
-    public void testSetDirectoryDirectoryCurrentlySynchronisingException() throws DirectoryCurrentlySynchronisingException, URISyntaxException {
+    public void testSetDirectoryDirectoryCurrentlySynchronisingException() throws DirectoryCurrentlySynchronisingException {
         Directory directory = createDirectory();
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
         doThrow(new DirectoryCurrentlySynchronisingException(1L)).when(crowdDirectoryService).removeDirectory(1L);

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/GadgetsServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/GadgetsServiceTest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -78,6 +79,7 @@ public class GadgetsServiceTest {
     public void testAddGadget() throws URISyntaxException, IllegalAccessException {
         ExternalGadgetSpec externalGadgetSpec = createExternalGadgetSpec();
         doReturn(Collections.singletonList(externalGadgetSpec)).when(externalGadgetSpecStore).entries();
+        doReturn(externalGadgetSpec).when(externalGadgetSpecStore).add(any());
 
         ConfluenceUser user = createConfluenceUser();
         String gadgetUrlToSet = externalGadgetSpec.getSpecUri().toString();
@@ -93,14 +95,15 @@ public class GadgetsServiceTest {
         doReturn(Locale.GERMAN).when(localeManager).getLocale(user);
         doReturn(gadgetSpec).when(gadgetSpecFactory).getGadgetSpec(externalGadgetSpec.getSpecUri(), null);
 
-        GadgetsBean gadgetsBean = gadgetsService.addGadget(gadgetBean);
-        assertEquals(gadgetUrlToSet, gadgetsBean.getGadgets().iterator().next().getUrl());
+        GadgetBean gadgetsBean = gadgetsService.addGadget(gadgetBean);
+        assertEquals(gadgetUrlToSet, gadgetsBean.getUrl());
     }
 
     @Test
     public void testSetGadgets() throws URISyntaxException, IllegalAccessException {
         ExternalGadgetSpec externalGadgetSpec = createExternalGadgetSpec();
         doReturn(Collections.singletonList(externalGadgetSpec)).when(externalGadgetSpecStore).entries();
+        doReturn(externalGadgetSpec).when(externalGadgetSpecStore).add(any());
 
         ConfluenceUser user = createConfluenceUser();
         String gadgetUrlToSet = externalGadgetSpec.getSpecUri().toString();

--- a/src/test/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confluence/confapi/service/LicensesServiceTest.java
@@ -69,11 +69,10 @@ public class LicensesServiceTest {
     public void testSetLicense() {
         LicenseBean licenseBean = LicenseBean.EXAMPLE_1;
         DefaultSingleProductLicenseDetailsView testLicense = new DefaultSingleProductLicenseDetailsView(licenseBean);
-        doReturn(testLicense).when(licenseHandler).getProductLicenseDetails(DEFAULT_LICENSE_REGISTRY_KEY);
 
-        LicensesBean updatedLicensesBean = licenseService.setLicense(licenseBean);
+        LicenseBean updatedLicenseBean = licenseService.addLicense(licenseBean);
 
-        assertEquals(testLicense.getDescription(), updatedLicensesBean.getLicenses().iterator().next().getDescription());
+        assertEquals(testLicense.getDescription(), updatedLicenseBean.getDescription());
     }
 
     @Test(expected = BadRequestException.class)
@@ -81,6 +80,6 @@ public class LicensesServiceTest {
         LicenseBean licenseBean = LicenseBean.EXAMPLE_1;
         doThrow(new InvalidOperationException("", "")).when(licenseHandler).addProductLicense(any(), any());
 
-        licenseService.setLicense(licenseBean);
+        licenseService.addLicense(licenseBean);
     }
 }


### PR DESCRIPTION
This commit adds Directory bean abstraction in order to accommodate different
types of directories (crowd, ldap etc...) using just a single directory endpoint.
DirectoryBaseBean represents the abstract base class whereas e.g. DirectoryCrowdBean
represents an actual bean implementation. At present Crowd is the only implemented
directory type.

In addition, service and resource renamings as well as single bean response type from 
the commons lib `addX` methods were integrated.